### PR TITLE
Reset internal counter when a COUNT rule is specified

### DIFF
--- a/When.php
+++ b/When.php
@@ -166,6 +166,7 @@ class When
 					break;
 				case "COUNT":
 					$this->count($param);
+					$this->counter = 0;
 					break;
 				case "INTERVAL":
 					$this->interval($param);


### PR DESCRIPTION
Minor bugfix: if a count is set as part of the RRULE, the internal counter needs to be reset, otherwise next() returns FALSE and drops out without returning additional dates.
