### PR TITLE
Make valid_date() public

### DIFF
--- a/When.php
+++ b/When.php
@@ -630,7 +630,7 @@ class When
 		}
 	}
 	
-	protected function valid_date($date)
+	public function valid_date($date)
 	{
 		$year = $date->format('Y');
 		$month = $date->format('n');


### PR DESCRIPTION
Is there any reason that valid_date() should be protected? It seems like it'd be useful to let another script find out if a given date falls on a recurring date.

`$r = new When();
        var_dump( $r->recur('20130104T090000')->rrule('FREQ=WEEKLY;UNTIL=20130216T003000Z;BYDAY=FR')->valid_date( new DateTime('yesterday') ) );`

If there's a better way to find this out, please let me know, thanks!
