### PR TITLE
Issue #8, FREQ=MONTHLY Rrule not working

### DIFF
--- a/Tests/When_Core_Test.php
+++ b/Tests/When_Core_Test.php
@@ -5,21 +5,21 @@ require_once 'PHPUnit/Framework.php';
 require_once './When.php';
 
 class When_Core_Tests extends PHPUnit_Framework_TestCase
-{	
+{
 	// passing an invalid DateTime
 	public function testInvalidDate()
 	{
 		$this->setExpectedException('InvalidArgumentException');
-		
+
 		$r = new When();
 		$r->recur('NOT A VALID TIME STAMP', 'yearly');
 	}
-	
+
 	// passing an invalid Frequency
 	public function testValidFrequencies()
 	{
 		$this->setExpectedException('InvalidArgumentException');
-		
+
 		$r = new When();
 		$r->recur('2000-01-01', 'yearlyy');
 	}

--- a/Tests/When_Daily_Rrule_Test.php
+++ b/Tests/When_Daily_Rrule_Test.php
@@ -23,16 +23,16 @@ class When_Daily_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-09-09 09:00:00');
 		$results[] = new DateTime('1997-09-10 09:00:00');
 		$results[] = new DateTime('1997-09-11 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=DAILY;COUNT=10');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Daily until December 24, 1997:
  	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -40,129 +40,129 @@ class When_Daily_Rrule_Test extends PHPUnit_Framework_TestCase
 	 */
 	function testThirtyFour()
 	{
-		$results[] = new DateTime('1997-09-02 09:00:00'); 
-		$results[] = new DateTime('1997-09-03 09:00:00'); 
-		$results[] = new DateTime('1997-09-04 09:00:00'); 
-		$results[] = new DateTime('1997-09-05 09:00:00'); 
-		$results[] = new DateTime('1997-09-06 09:00:00'); 
-		$results[] = new DateTime('1997-09-07 09:00:00'); 
-		$results[] = new DateTime('1997-09-08 09:00:00'); 
-		$results[] = new DateTime('1997-09-09 09:00:00'); 
-		$results[] = new DateTime('1997-09-10 09:00:00'); 
-		$results[] = new DateTime('1997-09-11 09:00:00'); 
-		$results[] = new DateTime('1997-09-12 09:00:00'); 
-		$results[] = new DateTime('1997-09-13 09:00:00'); 
-		$results[] = new DateTime('1997-09-14 09:00:00'); 
-		$results[] = new DateTime('1997-09-15 09:00:00'); 
-		$results[] = new DateTime('1997-09-16 09:00:00'); 
-		$results[] = new DateTime('1997-09-17 09:00:00'); 
-		$results[] = new DateTime('1997-09-18 09:00:00'); 
-		$results[] = new DateTime('1997-09-19 09:00:00'); 
-		$results[] = new DateTime('1997-09-20 09:00:00'); 
-		$results[] = new DateTime('1997-09-21 09:00:00'); 
-		$results[] = new DateTime('1997-09-22 09:00:00'); 
-		$results[] = new DateTime('1997-09-23 09:00:00'); 
-		$results[] = new DateTime('1997-09-24 09:00:00'); 
-		$results[] = new DateTime('1997-09-25 09:00:00'); 
-		$results[] = new DateTime('1997-09-26 09:00:00'); 
-		$results[] = new DateTime('1997-09-27 09:00:00'); 
-		$results[] = new DateTime('1997-09-28 09:00:00'); 
-		$results[] = new DateTime('1997-09-29 09:00:00'); 
-		$results[] = new DateTime('1997-09-30 09:00:00'); 
-		$results[] = new DateTime('1997-10-01 09:00:00'); 
-		$results[] = new DateTime('1997-10-02 09:00:00'); 
-		$results[] = new DateTime('1997-10-03 09:00:00'); 
-		$results[] = new DateTime('1997-10-04 09:00:00'); 
-		$results[] = new DateTime('1997-10-05 09:00:00'); 
-		$results[] = new DateTime('1997-10-06 09:00:00'); 
-		$results[] = new DateTime('1997-10-07 09:00:00'); 
-		$results[] = new DateTime('1997-10-08 09:00:00'); 
-		$results[] = new DateTime('1997-10-09 09:00:00'); 
-		$results[] = new DateTime('1997-10-10 09:00:00'); 
-		$results[] = new DateTime('1997-10-11 09:00:00'); 
-		$results[] = new DateTime('1997-10-12 09:00:00'); 
-		$results[] = new DateTime('1997-10-13 09:00:00'); 
-		$results[] = new DateTime('1997-10-14 09:00:00'); 
-		$results[] = new DateTime('1997-10-15 09:00:00'); 
-		$results[] = new DateTime('1997-10-16 09:00:00'); 
-		$results[] = new DateTime('1997-10-17 09:00:00'); 
-		$results[] = new DateTime('1997-10-18 09:00:00'); 
-		$results[] = new DateTime('1997-10-19 09:00:00'); 
-		$results[] = new DateTime('1997-10-20 09:00:00'); 
-		$results[] = new DateTime('1997-10-21 09:00:00'); 
-		$results[] = new DateTime('1997-10-22 09:00:00'); 
-		$results[] = new DateTime('1997-10-23 09:00:00'); 
-		$results[] = new DateTime('1997-10-24 09:00:00'); 
-		$results[] = new DateTime('1997-10-25 09:00:00'); 
-		$results[] = new DateTime('1997-10-26 09:00:00'); 
-		$results[] = new DateTime('1997-10-27 09:00:00'); 
-		$results[] = new DateTime('1997-10-28 09:00:00'); 
-		$results[] = new DateTime('1997-10-29 09:00:00'); 
-		$results[] = new DateTime('1997-10-30 09:00:00'); 
-		$results[] = new DateTime('1997-10-31 09:00:00'); 
-		$results[] = new DateTime('1997-11-01 09:00:00'); 
-		$results[] = new DateTime('1997-11-02 09:00:00'); 
-		$results[] = new DateTime('1997-11-03 09:00:00'); 
-		$results[] = new DateTime('1997-11-04 09:00:00'); 
-		$results[] = new DateTime('1997-11-05 09:00:00'); 
-		$results[] = new DateTime('1997-11-06 09:00:00'); 
-		$results[] = new DateTime('1997-11-07 09:00:00'); 
-		$results[] = new DateTime('1997-11-08 09:00:00'); 
-		$results[] = new DateTime('1997-11-09 09:00:00'); 
-		$results[] = new DateTime('1997-11-10 09:00:00'); 
-		$results[] = new DateTime('1997-11-11 09:00:00'); 
-		$results[] = new DateTime('1997-11-12 09:00:00'); 
-		$results[] = new DateTime('1997-11-13 09:00:00'); 
-		$results[] = new DateTime('1997-11-14 09:00:00'); 
-		$results[] = new DateTime('1997-11-15 09:00:00'); 
-		$results[] = new DateTime('1997-11-16 09:00:00'); 
-		$results[] = new DateTime('1997-11-17 09:00:00'); 
-		$results[] = new DateTime('1997-11-18 09:00:00'); 
-		$results[] = new DateTime('1997-11-19 09:00:00'); 
-		$results[] = new DateTime('1997-11-20 09:00:00'); 
-		$results[] = new DateTime('1997-11-21 09:00:00'); 
-		$results[] = new DateTime('1997-11-22 09:00:00'); 
-		$results[] = new DateTime('1997-11-23 09:00:00'); 
-		$results[] = new DateTime('1997-11-24 09:00:00'); 
-		$results[] = new DateTime('1997-11-25 09:00:00'); 
-		$results[] = new DateTime('1997-11-26 09:00:00'); 
-		$results[] = new DateTime('1997-11-27 09:00:00'); 
-		$results[] = new DateTime('1997-11-28 09:00:00'); 
-		$results[] = new DateTime('1997-11-29 09:00:00'); 
-		$results[] = new DateTime('1997-11-30 09:00:00'); 
-		$results[] = new DateTime('1997-12-01 09:00:00'); 
-		$results[] = new DateTime('1997-12-02 09:00:00'); 
-		$results[] = new DateTime('1997-12-03 09:00:00'); 
-		$results[] = new DateTime('1997-12-04 09:00:00'); 
-		$results[] = new DateTime('1997-12-05 09:00:00'); 
-		$results[] = new DateTime('1997-12-06 09:00:00'); 
-		$results[] = new DateTime('1997-12-07 09:00:00'); 
-		$results[] = new DateTime('1997-12-08 09:00:00'); 
-		$results[] = new DateTime('1997-12-09 09:00:00'); 
-		$results[] = new DateTime('1997-12-10 09:00:00'); 
-		$results[] = new DateTime('1997-12-11 09:00:00'); 
-		$results[] = new DateTime('1997-12-12 09:00:00'); 
-		$results[] = new DateTime('1997-12-13 09:00:00'); 
-		$results[] = new DateTime('1997-12-14 09:00:00'); 
-		$results[] = new DateTime('1997-12-15 09:00:00'); 
-		$results[] = new DateTime('1997-12-16 09:00:00'); 
-		$results[] = new DateTime('1997-12-17 09:00:00'); 
-		$results[] = new DateTime('1997-12-18 09:00:00'); 
-		$results[] = new DateTime('1997-12-19 09:00:00'); 
-		$results[] = new DateTime('1997-12-20 09:00:00'); 
-		$results[] = new DateTime('1997-12-21 09:00:00'); 
-		$results[] = new DateTime('1997-12-22 09:00:00'); 
-		$results[] = new DateTime('1997-12-23 09:00:00'); 
-		
+		$results[] = new DateTime('1997-09-02 09:00:00');
+		$results[] = new DateTime('1997-09-03 09:00:00');
+		$results[] = new DateTime('1997-09-04 09:00:00');
+		$results[] = new DateTime('1997-09-05 09:00:00');
+		$results[] = new DateTime('1997-09-06 09:00:00');
+		$results[] = new DateTime('1997-09-07 09:00:00');
+		$results[] = new DateTime('1997-09-08 09:00:00');
+		$results[] = new DateTime('1997-09-09 09:00:00');
+		$results[] = new DateTime('1997-09-10 09:00:00');
+		$results[] = new DateTime('1997-09-11 09:00:00');
+		$results[] = new DateTime('1997-09-12 09:00:00');
+		$results[] = new DateTime('1997-09-13 09:00:00');
+		$results[] = new DateTime('1997-09-14 09:00:00');
+		$results[] = new DateTime('1997-09-15 09:00:00');
+		$results[] = new DateTime('1997-09-16 09:00:00');
+		$results[] = new DateTime('1997-09-17 09:00:00');
+		$results[] = new DateTime('1997-09-18 09:00:00');
+		$results[] = new DateTime('1997-09-19 09:00:00');
+		$results[] = new DateTime('1997-09-20 09:00:00');
+		$results[] = new DateTime('1997-09-21 09:00:00');
+		$results[] = new DateTime('1997-09-22 09:00:00');
+		$results[] = new DateTime('1997-09-23 09:00:00');
+		$results[] = new DateTime('1997-09-24 09:00:00');
+		$results[] = new DateTime('1997-09-25 09:00:00');
+		$results[] = new DateTime('1997-09-26 09:00:00');
+		$results[] = new DateTime('1997-09-27 09:00:00');
+		$results[] = new DateTime('1997-09-28 09:00:00');
+		$results[] = new DateTime('1997-09-29 09:00:00');
+		$results[] = new DateTime('1997-09-30 09:00:00');
+		$results[] = new DateTime('1997-10-01 09:00:00');
+		$results[] = new DateTime('1997-10-02 09:00:00');
+		$results[] = new DateTime('1997-10-03 09:00:00');
+		$results[] = new DateTime('1997-10-04 09:00:00');
+		$results[] = new DateTime('1997-10-05 09:00:00');
+		$results[] = new DateTime('1997-10-06 09:00:00');
+		$results[] = new DateTime('1997-10-07 09:00:00');
+		$results[] = new DateTime('1997-10-08 09:00:00');
+		$results[] = new DateTime('1997-10-09 09:00:00');
+		$results[] = new DateTime('1997-10-10 09:00:00');
+		$results[] = new DateTime('1997-10-11 09:00:00');
+		$results[] = new DateTime('1997-10-12 09:00:00');
+		$results[] = new DateTime('1997-10-13 09:00:00');
+		$results[] = new DateTime('1997-10-14 09:00:00');
+		$results[] = new DateTime('1997-10-15 09:00:00');
+		$results[] = new DateTime('1997-10-16 09:00:00');
+		$results[] = new DateTime('1997-10-17 09:00:00');
+		$results[] = new DateTime('1997-10-18 09:00:00');
+		$results[] = new DateTime('1997-10-19 09:00:00');
+		$results[] = new DateTime('1997-10-20 09:00:00');
+		$results[] = new DateTime('1997-10-21 09:00:00');
+		$results[] = new DateTime('1997-10-22 09:00:00');
+		$results[] = new DateTime('1997-10-23 09:00:00');
+		$results[] = new DateTime('1997-10-24 09:00:00');
+		$results[] = new DateTime('1997-10-25 09:00:00');
+		$results[] = new DateTime('1997-10-26 09:00:00');
+		$results[] = new DateTime('1997-10-27 09:00:00');
+		$results[] = new DateTime('1997-10-28 09:00:00');
+		$results[] = new DateTime('1997-10-29 09:00:00');
+		$results[] = new DateTime('1997-10-30 09:00:00');
+		$results[] = new DateTime('1997-10-31 09:00:00');
+		$results[] = new DateTime('1997-11-01 09:00:00');
+		$results[] = new DateTime('1997-11-02 09:00:00');
+		$results[] = new DateTime('1997-11-03 09:00:00');
+		$results[] = new DateTime('1997-11-04 09:00:00');
+		$results[] = new DateTime('1997-11-05 09:00:00');
+		$results[] = new DateTime('1997-11-06 09:00:00');
+		$results[] = new DateTime('1997-11-07 09:00:00');
+		$results[] = new DateTime('1997-11-08 09:00:00');
+		$results[] = new DateTime('1997-11-09 09:00:00');
+		$results[] = new DateTime('1997-11-10 09:00:00');
+		$results[] = new DateTime('1997-11-11 09:00:00');
+		$results[] = new DateTime('1997-11-12 09:00:00');
+		$results[] = new DateTime('1997-11-13 09:00:00');
+		$results[] = new DateTime('1997-11-14 09:00:00');
+		$results[] = new DateTime('1997-11-15 09:00:00');
+		$results[] = new DateTime('1997-11-16 09:00:00');
+		$results[] = new DateTime('1997-11-17 09:00:00');
+		$results[] = new DateTime('1997-11-18 09:00:00');
+		$results[] = new DateTime('1997-11-19 09:00:00');
+		$results[] = new DateTime('1997-11-20 09:00:00');
+		$results[] = new DateTime('1997-11-21 09:00:00');
+		$results[] = new DateTime('1997-11-22 09:00:00');
+		$results[] = new DateTime('1997-11-23 09:00:00');
+		$results[] = new DateTime('1997-11-24 09:00:00');
+		$results[] = new DateTime('1997-11-25 09:00:00');
+		$results[] = new DateTime('1997-11-26 09:00:00');
+		$results[] = new DateTime('1997-11-27 09:00:00');
+		$results[] = new DateTime('1997-11-28 09:00:00');
+		$results[] = new DateTime('1997-11-29 09:00:00');
+		$results[] = new DateTime('1997-11-30 09:00:00');
+		$results[] = new DateTime('1997-12-01 09:00:00');
+		$results[] = new DateTime('1997-12-02 09:00:00');
+		$results[] = new DateTime('1997-12-03 09:00:00');
+		$results[] = new DateTime('1997-12-04 09:00:00');
+		$results[] = new DateTime('1997-12-05 09:00:00');
+		$results[] = new DateTime('1997-12-06 09:00:00');
+		$results[] = new DateTime('1997-12-07 09:00:00');
+		$results[] = new DateTime('1997-12-08 09:00:00');
+		$results[] = new DateTime('1997-12-09 09:00:00');
+		$results[] = new DateTime('1997-12-10 09:00:00');
+		$results[] = new DateTime('1997-12-11 09:00:00');
+		$results[] = new DateTime('1997-12-12 09:00:00');
+		$results[] = new DateTime('1997-12-13 09:00:00');
+		$results[] = new DateTime('1997-12-14 09:00:00');
+		$results[] = new DateTime('1997-12-15 09:00:00');
+		$results[] = new DateTime('1997-12-16 09:00:00');
+		$results[] = new DateTime('1997-12-17 09:00:00');
+		$results[] = new DateTime('1997-12-18 09:00:00');
+		$results[] = new DateTime('1997-12-19 09:00:00');
+		$results[] = new DateTime('1997-12-20 09:00:00');
+		$results[] = new DateTime('1997-12-21 09:00:00');
+		$results[] = new DateTime('1997-12-22 09:00:00');
+		$results[] = new DateTime('1997-12-23 09:00:00');
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=DAILY;UNTIL=19971224T000000Z');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every other day - forever:
 	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -170,64 +170,64 @@ class When_Daily_Rrule_Test extends PHPUnit_Framework_TestCase
 	 */
 	function testThirtyFive()
 	{
-		$results[] = new DateTime('1997-09-02 09:00:00'); 
-		$results[] = new DateTime('1997-09-04 09:00:00'); 
-		$results[] = new DateTime('1997-09-06 09:00:00'); 
-		$results[] = new DateTime('1997-09-08 09:00:00'); 
-		$results[] = new DateTime('1997-09-10 09:00:00'); 
-		$results[] = new DateTime('1997-09-12 09:00:00'); 
-		$results[] = new DateTime('1997-09-14 09:00:00'); 
-		$results[] = new DateTime('1997-09-16 09:00:00'); 
-		$results[] = new DateTime('1997-09-18 09:00:00'); 
-		$results[] = new DateTime('1997-09-20 09:00:00'); 
-		$results[] = new DateTime('1997-09-22 09:00:00'); 
-		$results[] = new DateTime('1997-09-24 09:00:00'); 
-		$results[] = new DateTime('1997-09-26 09:00:00'); 
-		$results[] = new DateTime('1997-09-28 09:00:00'); 
-		$results[] = new DateTime('1997-09-30 09:00:00'); 
-		$results[] = new DateTime('1997-10-02 09:00:00'); 
-		$results[] = new DateTime('1997-10-04 09:00:00'); 
-		$results[] = new DateTime('1997-10-06 09:00:00'); 
-		$results[] = new DateTime('1997-10-08 09:00:00'); 
-		$results[] = new DateTime('1997-10-10 09:00:00'); 
-		$results[] = new DateTime('1997-10-12 09:00:00'); 
-		$results[] = new DateTime('1997-10-14 09:00:00'); 
-		$results[] = new DateTime('1997-10-16 09:00:00'); 
-		$results[] = new DateTime('1997-10-18 09:00:00'); 
-		$results[] = new DateTime('1997-10-20 09:00:00'); 
-		$results[] = new DateTime('1997-10-22 09:00:00'); 
-		$results[] = new DateTime('1997-10-24 09:00:00'); 
-		$results[] = new DateTime('1997-10-26 09:00:00'); 
-		$results[] = new DateTime('1997-10-28 09:00:00'); 
-		$results[] = new DateTime('1997-10-30 09:00:00'); 
-		$results[] = new DateTime('1997-11-01 09:00:00'); 
-		$results[] = new DateTime('1997-11-03 09:00:00'); 
-		$results[] = new DateTime('1997-11-05 09:00:00'); 
-		$results[] = new DateTime('1997-11-07 09:00:00'); 
-		$results[] = new DateTime('1997-11-09 09:00:00'); 
-		$results[] = new DateTime('1997-11-11 09:00:00'); 
-		$results[] = new DateTime('1997-11-13 09:00:00'); 
-		$results[] = new DateTime('1997-11-15 09:00:00'); 
-		$results[] = new DateTime('1997-11-17 09:00:00'); 
-		$results[] = new DateTime('1997-11-19 09:00:00'); 
-		$results[] = new DateTime('1997-11-21 09:00:00'); 
-		$results[] = new DateTime('1997-11-23 09:00:00'); 
-		$results[] = new DateTime('1997-11-25 09:00:00'); 
-		$results[] = new DateTime('1997-11-27 09:00:00'); 
-		$results[] = new DateTime('1997-11-29 09:00:00'); 
-		$results[] = new DateTime('1997-12-01 09:00:00'); 
-		$results[] = new DateTime('1997-12-03 09:00:00'); 
-		
+		$results[] = new DateTime('1997-09-02 09:00:00');
+		$results[] = new DateTime('1997-09-04 09:00:00');
+		$results[] = new DateTime('1997-09-06 09:00:00');
+		$results[] = new DateTime('1997-09-08 09:00:00');
+		$results[] = new DateTime('1997-09-10 09:00:00');
+		$results[] = new DateTime('1997-09-12 09:00:00');
+		$results[] = new DateTime('1997-09-14 09:00:00');
+		$results[] = new DateTime('1997-09-16 09:00:00');
+		$results[] = new DateTime('1997-09-18 09:00:00');
+		$results[] = new DateTime('1997-09-20 09:00:00');
+		$results[] = new DateTime('1997-09-22 09:00:00');
+		$results[] = new DateTime('1997-09-24 09:00:00');
+		$results[] = new DateTime('1997-09-26 09:00:00');
+		$results[] = new DateTime('1997-09-28 09:00:00');
+		$results[] = new DateTime('1997-09-30 09:00:00');
+		$results[] = new DateTime('1997-10-02 09:00:00');
+		$results[] = new DateTime('1997-10-04 09:00:00');
+		$results[] = new DateTime('1997-10-06 09:00:00');
+		$results[] = new DateTime('1997-10-08 09:00:00');
+		$results[] = new DateTime('1997-10-10 09:00:00');
+		$results[] = new DateTime('1997-10-12 09:00:00');
+		$results[] = new DateTime('1997-10-14 09:00:00');
+		$results[] = new DateTime('1997-10-16 09:00:00');
+		$results[] = new DateTime('1997-10-18 09:00:00');
+		$results[] = new DateTime('1997-10-20 09:00:00');
+		$results[] = new DateTime('1997-10-22 09:00:00');
+		$results[] = new DateTime('1997-10-24 09:00:00');
+		$results[] = new DateTime('1997-10-26 09:00:00');
+		$results[] = new DateTime('1997-10-28 09:00:00');
+		$results[] = new DateTime('1997-10-30 09:00:00');
+		$results[] = new DateTime('1997-11-01 09:00:00');
+		$results[] = new DateTime('1997-11-03 09:00:00');
+		$results[] = new DateTime('1997-11-05 09:00:00');
+		$results[] = new DateTime('1997-11-07 09:00:00');
+		$results[] = new DateTime('1997-11-09 09:00:00');
+		$results[] = new DateTime('1997-11-11 09:00:00');
+		$results[] = new DateTime('1997-11-13 09:00:00');
+		$results[] = new DateTime('1997-11-15 09:00:00');
+		$results[] = new DateTime('1997-11-17 09:00:00');
+		$results[] = new DateTime('1997-11-19 09:00:00');
+		$results[] = new DateTime('1997-11-21 09:00:00');
+		$results[] = new DateTime('1997-11-23 09:00:00');
+		$results[] = new DateTime('1997-11-25 09:00:00');
+		$results[] = new DateTime('1997-11-27 09:00:00');
+		$results[] = new DateTime('1997-11-29 09:00:00');
+		$results[] = new DateTime('1997-12-01 09:00:00');
+		$results[] = new DateTime('1997-12-03 09:00:00');
+
 		$r = new When();
 		$r->recur('19970902T090000')->count(47)->rrule('FREQ=DAILY;INTERVAL=2');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
 
-	/**	
+	/**
 	 * Every 10 days, 5 occurrences:
 	 * DTSTART;TZID=America/New_York:19970902T090000
 	 * RRULE:FREQ=DAILY;INTERVAL=10;COUNT=5
@@ -239,16 +239,16 @@ class When_Daily_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-09-22 09:00:00');
 		$results[] = new DateTime('1997-10-02 09:00:00');
 		$results[] = new DateTime('1997-10-12 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=DAILY;INTERVAL=10;COUNT=5');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every day in January, for 3 years:
 	 * DTSTART;TZID=America/New_York:19980101T090000
@@ -349,10 +349,66 @@ class When_Daily_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2000-01-29 09:00:00');
 		$results[] = new DateTime('2000-01-30 09:00:00');
 		$results[] = new DateTime('2000-01-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19980101T090000')->rrule('FREQ=DAILY;UNTIL=20000131T140000Z;BYMONTH=1');
-		
+
+		foreach($results as $result)
+		{
+			$this->assertEquals($result, $r->next());
+		}
+	}
+
+	/**
+	 * RRULE:FREQ=DAILY
+	 */
+	function testThirtyEight()
+	{
+		$results[] = new DateTime('1997-09-02 09:00:00');
+		$results[] = new DateTime('1997-09-03 09:00:00');
+		$results[] = new DateTime('1997-09-04 09:00:00');
+		$results[] = new DateTime('1997-09-05 09:00:00');
+		$results[] = new DateTime('1997-09-06 09:00:00');
+		$results[] = new DateTime('1997-09-07 09:00:00');
+		$results[] = new DateTime('1997-09-08 09:00:00');
+		$results[] = new DateTime('1997-09-09 09:00:00');
+		$results[] = new DateTime('1997-09-10 09:00:00');
+		$results[] = new DateTime('1997-09-11 09:00:00');
+		$results[] = new DateTime('1997-09-12 09:00:00');
+		$results[] = new DateTime('1997-09-13 09:00:00');
+		$results[] = new DateTime('1997-09-14 09:00:00');
+		$results[] = new DateTime('1997-09-15 09:00:00');
+		$results[] = new DateTime('1997-09-16 09:00:00');
+
+		$r = new When();
+		$r->recur('19970902T090000')->rrule('FREQ=DAILY');
+
+		foreach($results as $result)
+		{
+			$this->assertEquals($result, $r->next());
+		}
+	}
+
+		/**
+	 * RRULE:FREQ=DAILY
+	 */
+	function testThirtyNine()
+	{
+		$results[] = new DateTime('1999-12-25 09:00:00');
+		$results[] = new DateTime('1999-12-26 09:00:00');
+		$results[] = new DateTime('1999-12-27 09:00:00');
+		$results[] = new DateTime('1999-12-28 09:00:00');
+		$results[] = new DateTime('1999-12-29 09:00:00');
+		$results[] = new DateTime('1999-12-30 09:00:00');
+		$results[] = new DateTime('1999-12-31 09:00:00');
+		$results[] = new DateTime('2000-01-01 09:00:00');
+		$results[] = new DateTime('2000-01-02 09:00:00');
+		$results[] = new DateTime('2000-01-03 09:00:00');
+		$results[] = new DateTime('2000-01-04 09:00:00');
+
+		$r = new When();
+		$r->recur('19991225T090000')->rrule('FREQ=DAILY');
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());

--- a/Tests/When_Daily_Test.php
+++ b/Tests/When_Daily_Test.php
@@ -23,16 +23,16 @@ class When_Daily_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-09-09 09:00:00');
 		$results[] = new DateTime('1997-09-10 09:00:00');
 		$results[] = new DateTime('1997-09-11 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'daily')->count(10);
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Daily until December 24, 1997:
  	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -40,129 +40,129 @@ class When_Daily_Test extends PHPUnit_Framework_TestCase
 	 */
 	function testThirtyFour()
 	{
-		$results[] = new DateTime('1997-09-02 09:00:00'); 
-		$results[] = new DateTime('1997-09-03 09:00:00'); 
-		$results[] = new DateTime('1997-09-04 09:00:00'); 
-		$results[] = new DateTime('1997-09-05 09:00:00'); 
-		$results[] = new DateTime('1997-09-06 09:00:00'); 
-		$results[] = new DateTime('1997-09-07 09:00:00'); 
-		$results[] = new DateTime('1997-09-08 09:00:00'); 
-		$results[] = new DateTime('1997-09-09 09:00:00'); 
-		$results[] = new DateTime('1997-09-10 09:00:00'); 
-		$results[] = new DateTime('1997-09-11 09:00:00'); 
-		$results[] = new DateTime('1997-09-12 09:00:00'); 
-		$results[] = new DateTime('1997-09-13 09:00:00'); 
-		$results[] = new DateTime('1997-09-14 09:00:00'); 
-		$results[] = new DateTime('1997-09-15 09:00:00'); 
-		$results[] = new DateTime('1997-09-16 09:00:00'); 
-		$results[] = new DateTime('1997-09-17 09:00:00'); 
-		$results[] = new DateTime('1997-09-18 09:00:00'); 
-		$results[] = new DateTime('1997-09-19 09:00:00'); 
-		$results[] = new DateTime('1997-09-20 09:00:00'); 
-		$results[] = new DateTime('1997-09-21 09:00:00'); 
-		$results[] = new DateTime('1997-09-22 09:00:00'); 
-		$results[] = new DateTime('1997-09-23 09:00:00'); 
-		$results[] = new DateTime('1997-09-24 09:00:00'); 
-		$results[] = new DateTime('1997-09-25 09:00:00'); 
-		$results[] = new DateTime('1997-09-26 09:00:00'); 
-		$results[] = new DateTime('1997-09-27 09:00:00'); 
-		$results[] = new DateTime('1997-09-28 09:00:00'); 
-		$results[] = new DateTime('1997-09-29 09:00:00'); 
-		$results[] = new DateTime('1997-09-30 09:00:00'); 
-		$results[] = new DateTime('1997-10-01 09:00:00'); 
-		$results[] = new DateTime('1997-10-02 09:00:00'); 
-		$results[] = new DateTime('1997-10-03 09:00:00'); 
-		$results[] = new DateTime('1997-10-04 09:00:00'); 
-		$results[] = new DateTime('1997-10-05 09:00:00'); 
-		$results[] = new DateTime('1997-10-06 09:00:00'); 
-		$results[] = new DateTime('1997-10-07 09:00:00'); 
-		$results[] = new DateTime('1997-10-08 09:00:00'); 
-		$results[] = new DateTime('1997-10-09 09:00:00'); 
-		$results[] = new DateTime('1997-10-10 09:00:00'); 
-		$results[] = new DateTime('1997-10-11 09:00:00'); 
-		$results[] = new DateTime('1997-10-12 09:00:00'); 
-		$results[] = new DateTime('1997-10-13 09:00:00'); 
-		$results[] = new DateTime('1997-10-14 09:00:00'); 
-		$results[] = new DateTime('1997-10-15 09:00:00'); 
-		$results[] = new DateTime('1997-10-16 09:00:00'); 
-		$results[] = new DateTime('1997-10-17 09:00:00'); 
-		$results[] = new DateTime('1997-10-18 09:00:00'); 
-		$results[] = new DateTime('1997-10-19 09:00:00'); 
-		$results[] = new DateTime('1997-10-20 09:00:00'); 
-		$results[] = new DateTime('1997-10-21 09:00:00'); 
-		$results[] = new DateTime('1997-10-22 09:00:00'); 
-		$results[] = new DateTime('1997-10-23 09:00:00'); 
-		$results[] = new DateTime('1997-10-24 09:00:00'); 
-		$results[] = new DateTime('1997-10-25 09:00:00'); 
-		$results[] = new DateTime('1997-10-26 09:00:00'); 
-		$results[] = new DateTime('1997-10-27 09:00:00'); 
-		$results[] = new DateTime('1997-10-28 09:00:00'); 
-		$results[] = new DateTime('1997-10-29 09:00:00'); 
-		$results[] = new DateTime('1997-10-30 09:00:00'); 
-		$results[] = new DateTime('1997-10-31 09:00:00'); 
-		$results[] = new DateTime('1997-11-01 09:00:00'); 
-		$results[] = new DateTime('1997-11-02 09:00:00'); 
-		$results[] = new DateTime('1997-11-03 09:00:00'); 
-		$results[] = new DateTime('1997-11-04 09:00:00'); 
-		$results[] = new DateTime('1997-11-05 09:00:00'); 
-		$results[] = new DateTime('1997-11-06 09:00:00'); 
-		$results[] = new DateTime('1997-11-07 09:00:00'); 
-		$results[] = new DateTime('1997-11-08 09:00:00'); 
-		$results[] = new DateTime('1997-11-09 09:00:00'); 
-		$results[] = new DateTime('1997-11-10 09:00:00'); 
-		$results[] = new DateTime('1997-11-11 09:00:00'); 
-		$results[] = new DateTime('1997-11-12 09:00:00'); 
-		$results[] = new DateTime('1997-11-13 09:00:00'); 
-		$results[] = new DateTime('1997-11-14 09:00:00'); 
-		$results[] = new DateTime('1997-11-15 09:00:00'); 
-		$results[] = new DateTime('1997-11-16 09:00:00'); 
-		$results[] = new DateTime('1997-11-17 09:00:00'); 
-		$results[] = new DateTime('1997-11-18 09:00:00'); 
-		$results[] = new DateTime('1997-11-19 09:00:00'); 
-		$results[] = new DateTime('1997-11-20 09:00:00'); 
-		$results[] = new DateTime('1997-11-21 09:00:00'); 
-		$results[] = new DateTime('1997-11-22 09:00:00'); 
-		$results[] = new DateTime('1997-11-23 09:00:00'); 
-		$results[] = new DateTime('1997-11-24 09:00:00'); 
-		$results[] = new DateTime('1997-11-25 09:00:00'); 
-		$results[] = new DateTime('1997-11-26 09:00:00'); 
-		$results[] = new DateTime('1997-11-27 09:00:00'); 
-		$results[] = new DateTime('1997-11-28 09:00:00'); 
-		$results[] = new DateTime('1997-11-29 09:00:00'); 
-		$results[] = new DateTime('1997-11-30 09:00:00'); 
-		$results[] = new DateTime('1997-12-01 09:00:00'); 
-		$results[] = new DateTime('1997-12-02 09:00:00'); 
-		$results[] = new DateTime('1997-12-03 09:00:00'); 
-		$results[] = new DateTime('1997-12-04 09:00:00'); 
-		$results[] = new DateTime('1997-12-05 09:00:00'); 
-		$results[] = new DateTime('1997-12-06 09:00:00'); 
-		$results[] = new DateTime('1997-12-07 09:00:00'); 
-		$results[] = new DateTime('1997-12-08 09:00:00'); 
-		$results[] = new DateTime('1997-12-09 09:00:00'); 
-		$results[] = new DateTime('1997-12-10 09:00:00'); 
-		$results[] = new DateTime('1997-12-11 09:00:00'); 
-		$results[] = new DateTime('1997-12-12 09:00:00'); 
-		$results[] = new DateTime('1997-12-13 09:00:00'); 
-		$results[] = new DateTime('1997-12-14 09:00:00'); 
-		$results[] = new DateTime('1997-12-15 09:00:00'); 
-		$results[] = new DateTime('1997-12-16 09:00:00'); 
-		$results[] = new DateTime('1997-12-17 09:00:00'); 
-		$results[] = new DateTime('1997-12-18 09:00:00'); 
-		$results[] = new DateTime('1997-12-19 09:00:00'); 
-		$results[] = new DateTime('1997-12-20 09:00:00'); 
-		$results[] = new DateTime('1997-12-21 09:00:00'); 
-		$results[] = new DateTime('1997-12-22 09:00:00'); 
-		$results[] = new DateTime('1997-12-23 09:00:00'); 
-		
+		$results[] = new DateTime('1997-09-02 09:00:00');
+		$results[] = new DateTime('1997-09-03 09:00:00');
+		$results[] = new DateTime('1997-09-04 09:00:00');
+		$results[] = new DateTime('1997-09-05 09:00:00');
+		$results[] = new DateTime('1997-09-06 09:00:00');
+		$results[] = new DateTime('1997-09-07 09:00:00');
+		$results[] = new DateTime('1997-09-08 09:00:00');
+		$results[] = new DateTime('1997-09-09 09:00:00');
+		$results[] = new DateTime('1997-09-10 09:00:00');
+		$results[] = new DateTime('1997-09-11 09:00:00');
+		$results[] = new DateTime('1997-09-12 09:00:00');
+		$results[] = new DateTime('1997-09-13 09:00:00');
+		$results[] = new DateTime('1997-09-14 09:00:00');
+		$results[] = new DateTime('1997-09-15 09:00:00');
+		$results[] = new DateTime('1997-09-16 09:00:00');
+		$results[] = new DateTime('1997-09-17 09:00:00');
+		$results[] = new DateTime('1997-09-18 09:00:00');
+		$results[] = new DateTime('1997-09-19 09:00:00');
+		$results[] = new DateTime('1997-09-20 09:00:00');
+		$results[] = new DateTime('1997-09-21 09:00:00');
+		$results[] = new DateTime('1997-09-22 09:00:00');
+		$results[] = new DateTime('1997-09-23 09:00:00');
+		$results[] = new DateTime('1997-09-24 09:00:00');
+		$results[] = new DateTime('1997-09-25 09:00:00');
+		$results[] = new DateTime('1997-09-26 09:00:00');
+		$results[] = new DateTime('1997-09-27 09:00:00');
+		$results[] = new DateTime('1997-09-28 09:00:00');
+		$results[] = new DateTime('1997-09-29 09:00:00');
+		$results[] = new DateTime('1997-09-30 09:00:00');
+		$results[] = new DateTime('1997-10-01 09:00:00');
+		$results[] = new DateTime('1997-10-02 09:00:00');
+		$results[] = new DateTime('1997-10-03 09:00:00');
+		$results[] = new DateTime('1997-10-04 09:00:00');
+		$results[] = new DateTime('1997-10-05 09:00:00');
+		$results[] = new DateTime('1997-10-06 09:00:00');
+		$results[] = new DateTime('1997-10-07 09:00:00');
+		$results[] = new DateTime('1997-10-08 09:00:00');
+		$results[] = new DateTime('1997-10-09 09:00:00');
+		$results[] = new DateTime('1997-10-10 09:00:00');
+		$results[] = new DateTime('1997-10-11 09:00:00');
+		$results[] = new DateTime('1997-10-12 09:00:00');
+		$results[] = new DateTime('1997-10-13 09:00:00');
+		$results[] = new DateTime('1997-10-14 09:00:00');
+		$results[] = new DateTime('1997-10-15 09:00:00');
+		$results[] = new DateTime('1997-10-16 09:00:00');
+		$results[] = new DateTime('1997-10-17 09:00:00');
+		$results[] = new DateTime('1997-10-18 09:00:00');
+		$results[] = new DateTime('1997-10-19 09:00:00');
+		$results[] = new DateTime('1997-10-20 09:00:00');
+		$results[] = new DateTime('1997-10-21 09:00:00');
+		$results[] = new DateTime('1997-10-22 09:00:00');
+		$results[] = new DateTime('1997-10-23 09:00:00');
+		$results[] = new DateTime('1997-10-24 09:00:00');
+		$results[] = new DateTime('1997-10-25 09:00:00');
+		$results[] = new DateTime('1997-10-26 09:00:00');
+		$results[] = new DateTime('1997-10-27 09:00:00');
+		$results[] = new DateTime('1997-10-28 09:00:00');
+		$results[] = new DateTime('1997-10-29 09:00:00');
+		$results[] = new DateTime('1997-10-30 09:00:00');
+		$results[] = new DateTime('1997-10-31 09:00:00');
+		$results[] = new DateTime('1997-11-01 09:00:00');
+		$results[] = new DateTime('1997-11-02 09:00:00');
+		$results[] = new DateTime('1997-11-03 09:00:00');
+		$results[] = new DateTime('1997-11-04 09:00:00');
+		$results[] = new DateTime('1997-11-05 09:00:00');
+		$results[] = new DateTime('1997-11-06 09:00:00');
+		$results[] = new DateTime('1997-11-07 09:00:00');
+		$results[] = new DateTime('1997-11-08 09:00:00');
+		$results[] = new DateTime('1997-11-09 09:00:00');
+		$results[] = new DateTime('1997-11-10 09:00:00');
+		$results[] = new DateTime('1997-11-11 09:00:00');
+		$results[] = new DateTime('1997-11-12 09:00:00');
+		$results[] = new DateTime('1997-11-13 09:00:00');
+		$results[] = new DateTime('1997-11-14 09:00:00');
+		$results[] = new DateTime('1997-11-15 09:00:00');
+		$results[] = new DateTime('1997-11-16 09:00:00');
+		$results[] = new DateTime('1997-11-17 09:00:00');
+		$results[] = new DateTime('1997-11-18 09:00:00');
+		$results[] = new DateTime('1997-11-19 09:00:00');
+		$results[] = new DateTime('1997-11-20 09:00:00');
+		$results[] = new DateTime('1997-11-21 09:00:00');
+		$results[] = new DateTime('1997-11-22 09:00:00');
+		$results[] = new DateTime('1997-11-23 09:00:00');
+		$results[] = new DateTime('1997-11-24 09:00:00');
+		$results[] = new DateTime('1997-11-25 09:00:00');
+		$results[] = new DateTime('1997-11-26 09:00:00');
+		$results[] = new DateTime('1997-11-27 09:00:00');
+		$results[] = new DateTime('1997-11-28 09:00:00');
+		$results[] = new DateTime('1997-11-29 09:00:00');
+		$results[] = new DateTime('1997-11-30 09:00:00');
+		$results[] = new DateTime('1997-12-01 09:00:00');
+		$results[] = new DateTime('1997-12-02 09:00:00');
+		$results[] = new DateTime('1997-12-03 09:00:00');
+		$results[] = new DateTime('1997-12-04 09:00:00');
+		$results[] = new DateTime('1997-12-05 09:00:00');
+		$results[] = new DateTime('1997-12-06 09:00:00');
+		$results[] = new DateTime('1997-12-07 09:00:00');
+		$results[] = new DateTime('1997-12-08 09:00:00');
+		$results[] = new DateTime('1997-12-09 09:00:00');
+		$results[] = new DateTime('1997-12-10 09:00:00');
+		$results[] = new DateTime('1997-12-11 09:00:00');
+		$results[] = new DateTime('1997-12-12 09:00:00');
+		$results[] = new DateTime('1997-12-13 09:00:00');
+		$results[] = new DateTime('1997-12-14 09:00:00');
+		$results[] = new DateTime('1997-12-15 09:00:00');
+		$results[] = new DateTime('1997-12-16 09:00:00');
+		$results[] = new DateTime('1997-12-17 09:00:00');
+		$results[] = new DateTime('1997-12-18 09:00:00');
+		$results[] = new DateTime('1997-12-19 09:00:00');
+		$results[] = new DateTime('1997-12-20 09:00:00');
+		$results[] = new DateTime('1997-12-21 09:00:00');
+		$results[] = new DateTime('1997-12-22 09:00:00');
+		$results[] = new DateTime('1997-12-23 09:00:00');
+
 		$r = new When();
 		$r->recur('19970902T090000', 'daily')->until('19971224T000000');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every other day - forever:
 	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -170,64 +170,64 @@ class When_Daily_Test extends PHPUnit_Framework_TestCase
 	 */
 	function testThirtyFive()
 	{
-		$results[] = new DateTime('1997-09-02 09:00:00'); 
-		$results[] = new DateTime('1997-09-04 09:00:00'); 
-		$results[] = new DateTime('1997-09-06 09:00:00'); 
-		$results[] = new DateTime('1997-09-08 09:00:00'); 
-		$results[] = new DateTime('1997-09-10 09:00:00'); 
-		$results[] = new DateTime('1997-09-12 09:00:00'); 
-		$results[] = new DateTime('1997-09-14 09:00:00'); 
-		$results[] = new DateTime('1997-09-16 09:00:00'); 
-		$results[] = new DateTime('1997-09-18 09:00:00'); 
-		$results[] = new DateTime('1997-09-20 09:00:00'); 
-		$results[] = new DateTime('1997-09-22 09:00:00'); 
-		$results[] = new DateTime('1997-09-24 09:00:00'); 
-		$results[] = new DateTime('1997-09-26 09:00:00'); 
-		$results[] = new DateTime('1997-09-28 09:00:00'); 
-		$results[] = new DateTime('1997-09-30 09:00:00'); 
-		$results[] = new DateTime('1997-10-02 09:00:00'); 
-		$results[] = new DateTime('1997-10-04 09:00:00'); 
-		$results[] = new DateTime('1997-10-06 09:00:00'); 
-		$results[] = new DateTime('1997-10-08 09:00:00'); 
-		$results[] = new DateTime('1997-10-10 09:00:00'); 
-		$results[] = new DateTime('1997-10-12 09:00:00'); 
-		$results[] = new DateTime('1997-10-14 09:00:00'); 
-		$results[] = new DateTime('1997-10-16 09:00:00'); 
-		$results[] = new DateTime('1997-10-18 09:00:00'); 
-		$results[] = new DateTime('1997-10-20 09:00:00'); 
-		$results[] = new DateTime('1997-10-22 09:00:00'); 
-		$results[] = new DateTime('1997-10-24 09:00:00'); 
-		$results[] = new DateTime('1997-10-26 09:00:00'); 
-		$results[] = new DateTime('1997-10-28 09:00:00'); 
-		$results[] = new DateTime('1997-10-30 09:00:00'); 
-		$results[] = new DateTime('1997-11-01 09:00:00'); 
-		$results[] = new DateTime('1997-11-03 09:00:00'); 
-		$results[] = new DateTime('1997-11-05 09:00:00'); 
-		$results[] = new DateTime('1997-11-07 09:00:00'); 
-		$results[] = new DateTime('1997-11-09 09:00:00'); 
-		$results[] = new DateTime('1997-11-11 09:00:00'); 
-		$results[] = new DateTime('1997-11-13 09:00:00'); 
-		$results[] = new DateTime('1997-11-15 09:00:00'); 
-		$results[] = new DateTime('1997-11-17 09:00:00'); 
-		$results[] = new DateTime('1997-11-19 09:00:00'); 
-		$results[] = new DateTime('1997-11-21 09:00:00'); 
-		$results[] = new DateTime('1997-11-23 09:00:00'); 
-		$results[] = new DateTime('1997-11-25 09:00:00'); 
-		$results[] = new DateTime('1997-11-27 09:00:00'); 
-		$results[] = new DateTime('1997-11-29 09:00:00'); 
-		$results[] = new DateTime('1997-12-01 09:00:00'); 
-		$results[] = new DateTime('1997-12-03 09:00:00'); 
-		
+		$results[] = new DateTime('1997-09-02 09:00:00');
+		$results[] = new DateTime('1997-09-04 09:00:00');
+		$results[] = new DateTime('1997-09-06 09:00:00');
+		$results[] = new DateTime('1997-09-08 09:00:00');
+		$results[] = new DateTime('1997-09-10 09:00:00');
+		$results[] = new DateTime('1997-09-12 09:00:00');
+		$results[] = new DateTime('1997-09-14 09:00:00');
+		$results[] = new DateTime('1997-09-16 09:00:00');
+		$results[] = new DateTime('1997-09-18 09:00:00');
+		$results[] = new DateTime('1997-09-20 09:00:00');
+		$results[] = new DateTime('1997-09-22 09:00:00');
+		$results[] = new DateTime('1997-09-24 09:00:00');
+		$results[] = new DateTime('1997-09-26 09:00:00');
+		$results[] = new DateTime('1997-09-28 09:00:00');
+		$results[] = new DateTime('1997-09-30 09:00:00');
+		$results[] = new DateTime('1997-10-02 09:00:00');
+		$results[] = new DateTime('1997-10-04 09:00:00');
+		$results[] = new DateTime('1997-10-06 09:00:00');
+		$results[] = new DateTime('1997-10-08 09:00:00');
+		$results[] = new DateTime('1997-10-10 09:00:00');
+		$results[] = new DateTime('1997-10-12 09:00:00');
+		$results[] = new DateTime('1997-10-14 09:00:00');
+		$results[] = new DateTime('1997-10-16 09:00:00');
+		$results[] = new DateTime('1997-10-18 09:00:00');
+		$results[] = new DateTime('1997-10-20 09:00:00');
+		$results[] = new DateTime('1997-10-22 09:00:00');
+		$results[] = new DateTime('1997-10-24 09:00:00');
+		$results[] = new DateTime('1997-10-26 09:00:00');
+		$results[] = new DateTime('1997-10-28 09:00:00');
+		$results[] = new DateTime('1997-10-30 09:00:00');
+		$results[] = new DateTime('1997-11-01 09:00:00');
+		$results[] = new DateTime('1997-11-03 09:00:00');
+		$results[] = new DateTime('1997-11-05 09:00:00');
+		$results[] = new DateTime('1997-11-07 09:00:00');
+		$results[] = new DateTime('1997-11-09 09:00:00');
+		$results[] = new DateTime('1997-11-11 09:00:00');
+		$results[] = new DateTime('1997-11-13 09:00:00');
+		$results[] = new DateTime('1997-11-15 09:00:00');
+		$results[] = new DateTime('1997-11-17 09:00:00');
+		$results[] = new DateTime('1997-11-19 09:00:00');
+		$results[] = new DateTime('1997-11-21 09:00:00');
+		$results[] = new DateTime('1997-11-23 09:00:00');
+		$results[] = new DateTime('1997-11-25 09:00:00');
+		$results[] = new DateTime('1997-11-27 09:00:00');
+		$results[] = new DateTime('1997-11-29 09:00:00');
+		$results[] = new DateTime('1997-12-01 09:00:00');
+		$results[] = new DateTime('1997-12-03 09:00:00');
+
 		$r = new When();
 		$r->recur('19970902T090000', 'daily')->interval(2)->count(47);
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
 
-	/**	
+	/**
 	 * Every 10 days, 5 occurrences:
 	 * DTSTART;TZID=America/New_York:19970902T090000
 	 * RRULE:FREQ=DAILY;INTERVAL=10;COUNT=5
@@ -239,16 +239,16 @@ class When_Daily_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-09-22 09:00:00');
 		$results[] = new DateTime('1997-10-02 09:00:00');
 		$results[] = new DateTime('1997-10-12 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'daily')->interval(10)->count(5);
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every day in January, for 3 years:
 	 * DTSTART;TZID=America/New_York:19980101T090000
@@ -349,10 +349,10 @@ class When_Daily_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2000-01-29 09:00:00');
 		$results[] = new DateTime('2000-01-30 09:00:00');
 		$results[] = new DateTime('2000-01-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19980101T090000', 'daily')->until('20000131T140000')->bymonth(array(1));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());

--- a/Tests/When_Iterator_Test.php
+++ b/Tests/When_Iterator_Test.php
@@ -5,7 +5,7 @@ require_once 'PHPUnit/Framework.php';
 require_once './When_Iterator.php';
 
 class When_Iterator_Tests extends PHPUnit_Framework_TestCase
-{	
+{
 
 	function testDateWithoutCache()
 	{
@@ -16,10 +16,10 @@ class When_Iterator_Tests extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-01-29 09:00:00');
 		$results[] = new DateTime('1998-02-26 09:00:00');
 		$results[] = new DateTime('1998-03-30 09:00:00');
-		
+
 		$r = new When_Iterator();
 		$r->recur('19970929T090000', 'monthly')->count(7)->byday(array('MO', 'TU', 'WE', 'TH', 'FR'))->bysetpos(array(-2));
-		
+
 		$counter = 0;
 		foreach($r as $result)
 		{
@@ -47,10 +47,10 @@ class When_Iterator_Tests extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-01-29 09:00:00');
 		$results[] = new DateTime('1998-02-26 09:00:00');
 		$results[] = new DateTime('1998-03-30 09:00:00');
-		
+
 		$r = new When_Iterator(true);
 		$r->recur('19970929T090000', 'monthly')->count(7)->byday(array('MO', 'TU', 'WE', 'TH', 'FR'))->bysetpos(array(-2));
-		
+
 		$counter = 0;
 		foreach($r as $result)
 		{

--- a/Tests/When_Monthly_Rrule_Test.php
+++ b/Tests/When_Monthly_Rrule_Test.php
@@ -23,16 +23,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-04-03 09:00:00');
 		$results[] = new DateTime('1998-05-01 09:00:00');
 		$results[] = new DateTime('1998-06-05 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970905T090000')->rrule('FREQ=MONTHLY;COUNT=10;BYDAY=1FR');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the 1st Friday until December 24, 1997:
 	 * DTSTART;TZID=US-Eastern:19970905T090000
@@ -44,17 +44,17 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-10-03 09:00:00');
 		$results[] = new DateTime('1997-11-07 09:00:00');
 		$results[] = new DateTime('1997-12-05 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970905T090000')->rrule('FREQ=MONTHLY;UNTIL=19971224T000000Z;BYDAY=1FR');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
 
-	/**	
+	/**
 	 * Every other month on the 1st and last Sunday of the month for 10 occurrences:
 	 * DTSTART;TZID=US-Eastern:19970907T090000
 	 * RRULE:FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU
@@ -71,16 +71,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-03-29 09:00:00');
 		$results[] = new DateTime('1998-05-03 09:00:00');
 		$results[] = new DateTime('1998-05-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970905T090000')->rrule('FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the second to last Monday of the month for 6 months:
 	 * DTSTART;TZID=US-Eastern:19970922T090000
@@ -94,16 +94,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-22 09:00:00');
 		$results[] = new DateTime('1998-01-19 09:00:00');
 		$results[] = new DateTime('1998-02-16 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970922T090000')->rrule('FREQ=MONTHLY;COUNT=6;BYDAY=-2MO');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the third to the last day of the month, forever:
 	 * DTSTART;TZID=US-Eastern:19970928T090000
@@ -117,16 +117,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-29 09:00:00');
 		$results[] = new DateTime('1998-01-29 09:00:00');
 		$results[] = new DateTime('1998-02-26 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->count(6)->rrule('FREQ=MONTHLY;BYMONTHDAY=-3');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the 2nd and 15th of the month for 10 occurrences:
 	 * DTSTART;TZID=US-Eastern:19970902T090000
@@ -144,16 +144,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-15 09:00:00');
 		$results[] = new DateTime('1998-01-02 09:00:00');
 		$results[] = new DateTime('1998-01-15 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=MONTHLY;COUNT=10;BYMONTHDAY=2,15');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the first and last day of the month for 10 occurrences:
 	 * DTSTART;TZID=US-Eastern:19970930T090000
@@ -171,7 +171,7 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-01-01 09:00:00');
 		$results[] = new DateTime('1998-01-31 09:00:00');
 		$results[] = new DateTime('1998-02-01 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970930T090000')->rrule('RRULE:FREQ=MONTHLY;COUNT=10;BYMONTHDAY=1,-1');
 
@@ -180,7 +180,7 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every 18 months on the 10th thru 15th of the month for 10 occurrences:
 	 * DTSTART;TZID=US-Eastern:19970910T090000
@@ -198,16 +198,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1999-03-11 09:00:00');
 		$results[] = new DateTime('1999-03-12 09:00:00');
 		$results[] = new DateTime('1999-03-13 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970910T090000')->rrule('FREQ=MONTHLY;INTERVAL=18;COUNT=10;BYMONTHDAY=10,11,12,13,14,15');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every Tuesday, every other month:
 	 * DTSTART;TZID=US-Eastern:19970902T090000
@@ -233,16 +233,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-03-17 09:00:00');
 		$results[] = new DateTime('1998-03-24 09:00:00');
 		$results[] = new DateTime('1998-03-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->count(18)->rrule('FREQ=MONTHLY;INTERVAL=2;BYDAY=TU');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every Friday the 13th, forever:
 	 * DTSTART;TZID=US-Eastern:19970902T090000
@@ -255,16 +255,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-11-13 09:00:00');
 		$results[] = new DateTime('1999-08-13 09:00:00');
 		$results[] = new DateTime('2000-10-13 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->count(5)->rrule('FREQ=MONTHLY;BYDAY=FR;BYMONTHDAY=13');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * The first Saturday that follows the first Sunday of the month, forever:
 	 * DTSTART;TZID=US-Eastern:19970913T090000
@@ -282,16 +282,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-04-11 09:00:00');
 		$results[] = new DateTime('1998-05-09 09:00:00');
 		$results[] = new DateTime('1998-06-13 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970913T090000')->count(10)->rrule('FREQ=MONTHLY;BYDAY=SA;BYMONTHDAY=7,8,9,10,11,12,13');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
      * The 3rd instance into the month of one of Tuesday, Wednesday or Thursday, for the next 3 months:
 	 * DTSTART;TZID=US-Eastern:19970904T090000
@@ -302,16 +302,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-09-04 09:00:00');
 		$results[] = new DateTime('1997-10-07 09:00:00');
 		$results[] = new DateTime('1997-11-06 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970904T090000')->rrule('FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * An example where an invalid date (i.e., February 30) is ignored.
 	 * DTSTART;TZID=America/New_York:20070115T090000
@@ -324,16 +324,16 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2007-02-15 09:00:00');
 		$results[] = new DateTime('2007-03-15 09:00:00');
 		$results[] = new DateTime('2007-03-30 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('20070115T090000')->count(5)->rrule('FREQ=MONTHLY;BYMONTHDAY=15,30;COUNT=5');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * The second-to-last weekday of the month:
 	 * DTSTART;TZID=America/New_York:19970929T090000
@@ -348,13 +348,47 @@ class When_Monthly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-01-29 09:00:00');
 		$results[] = new DateTime('1998-02-26 09:00:00');
 		$results[] = new DateTime('1998-03-30 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970929T090000')->count(7)->rrule('FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-2');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
+		}
+	}
+
+	/**
+	 * The same day of every month:
+	 * RRULE:FREQ=MONTHLY
+	 */
+	function testTwentyThree()
+	{
+		$results[] = new DateTime('1997-09-14 09:00:00');
+		$results[] = new DateTime('1997-10-14 09:00:00');
+		$results[] = new DateTime('1997-11-14 09:00:00');
+		$results[] = new DateTime('1997-12-14 09:00:00');
+		$results[] = new DateTime('1998-01-14 09:00:00');
+		$results[] = new DateTime('1998-02-14 09:00:00');
+		$results[] = new DateTime('1998-03-14 09:00:00');
+		$results[] = new DateTime('1998-04-14 09:00:00');
+		$results[] = new DateTime('1998-05-14 09:00:00');
+		$results[] = new DateTime('1998-06-14 09:00:00');
+		$results[] = new DateTime('1998-07-14 09:00:00');
+		$results[] = new DateTime('1998-08-14 09:00:00');
+		$results[] = new DateTime('1998-09-14 09:00:00');
+		$results[] = new DateTime('1998-10-14 09:00:00');
+		$results[] = new DateTime('1998-11-14 09:00:00');
+		$results[] = new DateTime('1998-12-14 09:00:00');
+		$results[] = new DateTime('1999-01-14 09:00:00');
+
+		$r = new When();
+		$r->recur('19970914T090000')->count(17)->rrule('FREQ=MONTHLY');
+
+		foreach($results as $result)
+		{
+			$date = $r->next();
+			$this->assertEquals($result, $date);
 		}
 	}
 }

--- a/Tests/When_Monthly_Test.php
+++ b/Tests/When_Monthly_Test.php
@@ -23,16 +23,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-04-03 09:00:00');
 		$results[] = new DateTime('1998-05-01 09:00:00');
 		$results[] = new DateTime('1998-06-05 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970905T090000', 'monthly')->count(10)->byday(array('1FR'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the 1st Friday until December 24, 1997:
 	 * DTSTART;TZID=US-Eastern:19970905T090000
@@ -44,17 +44,17 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-10-03 09:00:00');
 		$results[] = new DateTime('1997-11-07 09:00:00');
 		$results[] = new DateTime('1997-12-05 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970905T090000', 'monthly')->until('19971224T000000')->byday(array('1FR'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
 
-	/**	
+	/**
 	 * Every other month on the 1st and last Sunday of the month for 10 occurrences:
 	 * DTSTART;TZID=US-Eastern:19970907T090000
 	 * RRULE:FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=1SU,-1SU
@@ -71,16 +71,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-03-29 09:00:00');
 		$results[] = new DateTime('1998-05-03 09:00:00');
 		$results[] = new DateTime('1998-05-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970905T090000', 'monthly')->interval(2)->count(10)->byday(array('1SU', '-1SU'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the second to last Monday of the month for 6 months:
 	 * DTSTART;TZID=US-Eastern:19970922T090000
@@ -94,16 +94,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-22 09:00:00');
 		$results[] = new DateTime('1998-01-19 09:00:00');
 		$results[] = new DateTime('1998-02-16 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970922T090000', 'monthly')->count(6)->byday(array('-2MO'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the third to the last day of the month, forever:
 	 * DTSTART;TZID=US-Eastern:19970928T090000
@@ -117,16 +117,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-29 09:00:00');
 		$results[] = new DateTime('1998-01-29 09:00:00');
 		$results[] = new DateTime('1998-02-26 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'monthly')->count(6)->bymonthday(array(-3));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the 2nd and 15th of the month for 10 occurrences:
 	 * DTSTART;TZID=US-Eastern:19970902T090000
@@ -144,16 +144,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-15 09:00:00');
 		$results[] = new DateTime('1998-01-02 09:00:00');
 		$results[] = new DateTime('1998-01-15 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'monthly')->count(10)->bymonthday(array(2,15));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monthly on the first and last day of the month for 10 occurrences:
 	 * DTSTART;TZID=US-Eastern:19970930T090000
@@ -171,7 +171,7 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-01-01 09:00:00');
 		$results[] = new DateTime('1998-01-31 09:00:00');
 		$results[] = new DateTime('1998-02-01 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970930T090000', 'monthly')->count(10)->bymonthday(array(1,-1));
 
@@ -180,7 +180,7 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every 18 months on the 10th thru 15th of the month for 10 occurrences:
 	 * DTSTART;TZID=US-Eastern:19970910T090000
@@ -198,16 +198,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1999-03-11 09:00:00');
 		$results[] = new DateTime('1999-03-12 09:00:00');
 		$results[] = new DateTime('1999-03-13 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970910T090000', 'monthly')->interval(18)->count(10)->bymonthday(array(10,11,12,13,14,15));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every Tuesday, every other month:
 	 * DTSTART;TZID=US-Eastern:19970902T090000
@@ -233,16 +233,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-03-17 09:00:00');
 		$results[] = new DateTime('1998-03-24 09:00:00');
 		$results[] = new DateTime('1998-03-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'monthly')->interval(2)->count(18)->byday(array('TU'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every Friday the 13th, forever:
 	 * DTSTART;TZID=US-Eastern:19970902T090000
@@ -255,16 +255,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-11-13 09:00:00');
 		$results[] = new DateTime('1999-08-13 09:00:00');
 		$results[] = new DateTime('2000-10-13 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'monthly')->count(5)->byday(array('FR'))->bymonthday(array(13));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * The first Saturday that follows the first Sunday of the month, forever:
 	 * DTSTART;TZID=US-Eastern:19970913T090000
@@ -282,16 +282,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-04-11 09:00:00');
 		$results[] = new DateTime('1998-05-09 09:00:00');
 		$results[] = new DateTime('1998-06-13 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970913T090000', 'monthly')->count(10)->byday(array('SA'))->bymonthday(array(7,8,9,10,11,12,13));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
      * The 3rd instance into the month of one of Tuesday, Wednesday or Thursday, for the next 3 months:
 	 * DTSTART;TZID=US-Eastern:19970904T090000
@@ -302,16 +302,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-09-04 09:00:00');
 		$results[] = new DateTime('1997-10-07 09:00:00');
 		$results[] = new DateTime('1997-11-06 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970904T090000', 'monthly')->count(3)->byday(array('TU', 'WE', 'TH'))->bysetpos(array(3));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * An example where an invalid date (i.e., February 30) is ignored.
 	 * DTSTART;TZID=America/New_York:20070115T090000
@@ -324,16 +324,16 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2007-02-15 09:00:00');
 		$results[] = new DateTime('2007-03-15 09:00:00');
 		$results[] = new DateTime('2007-03-30 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('20070115T090000', 'monthly')->count(5)->bymonthday(array(15,30));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * The second-to-last weekday of the month:
 	 * DTSTART;TZID=America/New_York:19970929T090000
@@ -348,10 +348,10 @@ class When_Monthly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-01-29 09:00:00');
 		$results[] = new DateTime('1998-02-26 09:00:00');
 		$results[] = new DateTime('1998-03-30 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970929T090000', 'monthly')->count(7)->byday(array('MO', 'TU', 'WE', 'TH', 'FR'))->bysetpos(array(-2));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());

--- a/Tests/When_Weekly_Rrule_Test.php
+++ b/Tests/When_Weekly_Rrule_Test.php
@@ -23,17 +23,17 @@ class When_Weekly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-10-21 09:00:00');
 		$results[] = new DateTime('1997-10-28 09:00:00');
 		$results[] = new DateTime('1997-11-04 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=WEEKLY;COUNT=10');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
-	/**	
+
+	/**
 	 * Weekly until December 24, 1997:
 	 * DTSTART;TZID=America/New_York:19970902T090000
 	 * RRULE:FREQ=WEEKLY;UNTIL=19971224T000000Z
@@ -57,16 +57,16 @@ class When_Weekly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-09 09:00:00');
 		$results[] = new DateTime('1997-12-16 09:00:00');
 		$results[] = new DateTime('1997-12-23 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=WEEKLY;UNTIL=19971224T000000Z');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every other week - forever:
 	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -87,16 +87,16 @@ class When_Weekly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-01-20 09:00:00');
 		$results[] = new DateTime('1998-02-03 09:00:00');
 		$results[] = new DateTime('1998-02-17 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=WEEKLY;INTERVAL=2;WKST=SU');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Weekly on Tuesday and Thursday for five weeks:
 	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -116,26 +116,26 @@ class When_Weekly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-09-25 09:00:00');
 		$results[] = new DateTime('1997-09-30 09:00:00');
 		$results[] = new DateTime('1997-10-02 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=WEEKLY;UNTIL=19971007T000000Z;WKST=SU;BYDAY=TU,TH');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
-		
+
 		unset($r);
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=WEEKLY;COUNT=10;WKST=SU;BYDAY=TU,TH');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every other week on Monday, Wednesday, and Friday until December 24, 1997, starting on Monday, September 1, 1997:
 	 * DTSTART;TZID=America/New_York:19970901T090000
@@ -168,16 +168,16 @@ class When_Weekly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-10 09:00:00');
 		$results[] = new DateTime('1997-12-12 09:00:00');
 		$results[] = new DateTime('1997-12-22 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970901T090000')->rrule('FREQ=WEEKLY;INTERVAL=2;UNTIL=19971224T000000Z;WKST=SU;BYDAY=MO,WE,FR');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every other week on Tuesday and Thursday, for 8 occurrences:
 	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -193,16 +193,16 @@ class When_Weekly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-10-02 09:00:00');
 		$results[] = new DateTime('1997-10-14 09:00:00');
 		$results[] = new DateTime('1997-10-16 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000')->rrule('FREQ=WEEKLY;INTERVAL=2;COUNT=8;WKST=SU;BYDAY=TU,TH');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * An example where the days generated makes a difference because of WKST:
 	 * DTSTART;TZID=America/New_York:19970805T090000
@@ -214,16 +214,16 @@ class When_Weekly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-08-10 09:00:00');
 		$results[] = new DateTime('1997-08-19 09:00:00');
 		$results[] = new DateTime('1997-08-24 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970805T090000')->rrule('FREQ=WEEKLY;INTERVAL=2;COUNT=4;BYDAY=TU,SU;WKST=MO');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * changing only WKST from MO to SU, yields different results...
 	 * DTSTART;TZID=America/New_York:19970805T090000
@@ -235,10 +235,10 @@ class When_Weekly_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-08-17 09:00:00');
 		$results[] = new DateTime('1997-08-19 09:00:00');
 		$results[] = new DateTime('1997-08-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970805T090000')->rrule('FREQ=WEEKLY;INTERVAL=2;COUNT=4;BYDAY=TU,SU;WKST=SU');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());

--- a/Tests/When_Weekly_Test.php
+++ b/Tests/When_Weekly_Test.php
@@ -23,17 +23,17 @@ class When_Weekly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-10-21 09:00:00');
 		$results[] = new DateTime('1997-10-28 09:00:00');
 		$results[] = new DateTime('1997-11-04 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'weekly')->count(10);
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
-	/**	
+
+	/**
 	 * Weekly until December 24, 1997:
 	 * DTSTART;TZID=America/New_York:19970902T090000
 	 * RRULE:FREQ=WEEKLY;UNTIL=19971224T000000Z
@@ -57,16 +57,16 @@ class When_Weekly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-09 09:00:00');
 		$results[] = new DateTime('1997-12-16 09:00:00');
 		$results[] = new DateTime('1997-12-23 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'weekly')->until('19971224T000000');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every other week - forever:
 	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -87,16 +87,16 @@ class When_Weekly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1998-01-20 09:00:00');
 		$results[] = new DateTime('1998-02-03 09:00:00');
 		$results[] = new DateTime('1998-02-17 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'weekly')->count(13)->interval(2)->wkst('SU');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Weekly on Tuesday and Thursday for five weeks:
 	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -116,26 +116,26 @@ class When_Weekly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-09-25 09:00:00');
 		$results[] = new DateTime('1997-09-30 09:00:00');
 		$results[] = new DateTime('1997-10-02 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'weekly')->until('19971007T000000')->wkst('SU')->byday(array('TU', 'TH'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
-		
+
 		unset($r);
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'weekly')->count(10)->wkst('SU')->byday(array('TU', 'TH'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every other week on Monday, Wednesday, and Friday until December 24, 1997, starting on Monday, September 1, 1997:
 	 * DTSTART;TZID=America/New_York:19970901T090000
@@ -168,16 +168,16 @@ class When_Weekly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-12-10 09:00:00');
 		$results[] = new DateTime('1997-12-12 09:00:00');
 		$results[] = new DateTime('1997-12-22 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970901T090000', 'weekly')->until('19971224T000000')->wkst('SU')->interval(2)->byday(array('MO', 'WE', 'FR'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every other week on Tuesday and Thursday, for 8 occurrences:
 	 * DTSTART;TZID=America/New_York:19970902T090000
@@ -193,16 +193,16 @@ class When_Weekly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-10-02 09:00:00');
 		$results[] = new DateTime('1997-10-14 09:00:00');
 		$results[] = new DateTime('1997-10-16 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970902T090000', 'weekly')->interval(2)->count(8)->wkst('SU')->byday(array('TU', 'TH'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * An example where the days generated makes a difference because of WKST:
 	 * DTSTART;TZID=America/New_York:19970805T090000
@@ -214,16 +214,16 @@ class When_Weekly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-08-10 09:00:00');
 		$results[] = new DateTime('1997-08-19 09:00:00');
 		$results[] = new DateTime('1997-08-24 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970805T090000', 'weekly')->interval(2)->count(4)->byday(array('TU', 'SU'))->wkst('MO');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * changing only WKST from MO to SU, yields different results...
 	 * DTSTART;TZID=America/New_York:19970805T090000
@@ -235,10 +235,10 @@ class When_Weekly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1997-08-17 09:00:00');
 		$results[] = new DateTime('1997-08-19 09:00:00');
 		$results[] = new DateTime('1997-08-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970805T090000', 'weekly')->interval(2)->count(4)->byday(array('TU', 'SU'))->wkst('SU');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());

--- a/Tests/When_Yearly_Rrule_Test.php
+++ b/Tests/When_Yearly_Rrule_Test.php
@@ -22,16 +22,16 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2000-07-10 09:00:00');
 		$results[] = new DateTime('2001-06-10 09:00:00');
 		$results[] = new DateTime('2001-07-10 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970610T090000')->rrule('FREQ=YEARLY;COUNT=10;BYMONTH=6,7');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * DTSTART;TZID=US-Eastern:19970101T090000
 	 * RRULE:FREQ=YEARLY;INTERVAL=3;COUNT=10;BYYEARDAY=1,100,200
@@ -48,16 +48,16 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2003-04-10 09:00:00');
 		$results[] = new DateTime('2003-07-19 09:00:00');
 		$results[] = new DateTime('2006-01-01 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970101T090000')->rrule('FREQ=YEARLY;INTERVAL=3;COUNT=10;BYYEARDAY=1,100,200');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * DTSTART;TZID=US-Eastern:19970310T090000
 	 * RRULE:FREQ=YEARLY;INTERVAL=2;COUNT=10;BYMONTH=1,2,3
@@ -74,16 +74,16 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2003-01-10 09:00:00');
 		$results[] = new DateTime('2003-02-10 09:00:00');
 		$results[] = new DateTime('2003-03-10 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970310T090000')->rrule('FREQ=YEARLY;INTERVAL=2;COUNT=10;BYMONTH=1,2,3');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * DTSTART;TZID=US-Eastern:19980101T090000
 	 * RRULE:FREQ=YEARLY;UNTIL=20000131T090000Z;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA
@@ -183,16 +183,16 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2000-01-29 09:00:00');
 		$results[] = new DateTime('2000-01-30 09:00:00');
 		$results[] = new DateTime('2000-01-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19980101T090000')->rrule('FREQ=YEARLY;UNTIL=20000131T090000Z;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monday of week number 20 (where the default start of the week is Monday), forever:
 	 * DTSTART;TZID=US-Eastern:19970512T090000
@@ -211,17 +211,17 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2004-05-10 09:00:00');
 		$results[] = new DateTime('2005-05-16 09:00:00');
 		$results[] = new DateTime('2006-05-15 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970512T090000')->count(10)->rrule('FREQ=YEARLY;BYWEEKNO=20;BYDAY=MO');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	 }
-	 
-	 /** 
+
+	 /**
 	  * Every Thursday in March, forever:
 	  * DTSTART;TZID=US-Eastern:19970313T090000
 	  * RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=TH
@@ -238,16 +238,16 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1999-03-04 09:00:00');
 		$results[] = new DateTime('1999-03-11 09:00:00');
 		$results[] = new DateTime('1999-03-18 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970313T090000')->count(10)->rrule('FREQ=YEARLY;BYMONTH=3;BYDAY=TH');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	 }
-	 
+
 	/**
 	 * Every Thursday, but only during June, July, and August, forever:
 	 * DTSTART;TZID=US-Eastern:19970605T090000
@@ -294,16 +294,16 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1999-08-12 09:00:00');
 		$results[] = new DateTime('1999-08-19 09:00:00');
 		$results[] = new DateTime('1999-08-26 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970605T090000')->count(39)->rrule('FREQ=YEARLY;BYDAY=TH;BYMONTH=6,7,8');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every four years, the first Tuesday after a Monday in November, forever (U.S. Presidential Election day):
 	 * DTSTART;TZID=US-Eastern:19961105T090000
@@ -321,16 +321,16 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2024-11-05 09:00:00');
 		$results[] = new DateTime('2028-11-07 09:00:00');
 		$results[] = new DateTime('2032-11-02 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19961105T090000')->count(10)->rrule('FREQ=YEARLY;INTERVAL=4;BYMONTH=11;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every third year on the 1st, 100th, and 200th day for 10 occurrences:
 	 * DTSTART;TZID=America/New_York:19970101T090000
@@ -348,16 +348,16 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2003-04-10 09:00:00');
 		$results[] = new DateTime('2003-07-19 09:00:00');
 		$results[] = new DateTime('2006-01-01 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970101T090000')->rrule('FREQ=YEARLY;INTERVAL=3;COUNT=10;BYYEARDAY=1,100,200');
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every year on the -1th, -100th, and -200th day for 5 occurrences (checked via google calendar import below)
 	 * BEGIN:VCALENDAR
@@ -405,10 +405,28 @@ class When_Rrule_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2010-06-15 09:00:00');
 		$results[] = new DateTime('2011-12-31 09:00:00');
 		$results[] = new DateTime('2011-09-23 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('20101231T090000')->rrule('FREQ=YEARLY;COUNT=5;BYYEARDAY=-1,-100,-200');
-		
+
+		foreach($results as $result)
+		{
+			$this->assertEquals($result, $r->next());
+		}
+	}
+
+	function testTwentyFive()
+	{
+		$results[] = new DateTime('2010-01-15 09:00:00');
+		$results[] = new DateTime('2011-01-15 09:00:00');
+		$results[] = new DateTime('2012-01-15 09:00:00');
+		$results[] = new DateTime('2013-01-15 09:00:00');
+		$results[] = new DateTime('2014-01-15 09:00:00');
+		$results[] = new DateTime('2015-01-15 09:00:00');
+
+		$r = new When();
+		$r->recur('20100115T090000')->rrule('FREQ=YEARLY');
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());

--- a/Tests/When_Yearly_Test.php
+++ b/Tests/When_Yearly_Test.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'PHPUnit/Framework.php';
+
 
 require_once './When.php';
 
@@ -22,16 +22,16 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2000-07-10 09:00:00');
 		$results[] = new DateTime('2001-06-10 09:00:00');
 		$results[] = new DateTime('2001-07-10 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970610T090000', 'yearly')->count(10)->bymonth(array(6,7));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * DTSTART;TZID=US-Eastern:19970101T090000
 	 * RRULE:FREQ=YEARLY;INTERVAL=3;COUNT=10;BYYEARDAY=1,100,200
@@ -48,16 +48,16 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2003-04-10 09:00:00');
 		$results[] = new DateTime('2003-07-19 09:00:00');
 		$results[] = new DateTime('2006-01-01 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970101T090000', 'yearly')->interval(3)->count(10)->byyearday(array(1,100,200));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * DTSTART;TZID=US-Eastern:19970310T090000
 	 * RRULE:FREQ=YEARLY;INTERVAL=2;COUNT=10;BYMONTH=1,2,3
@@ -74,16 +74,16 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2003-01-10 09:00:00');
 		$results[] = new DateTime('2003-02-10 09:00:00');
 		$results[] = new DateTime('2003-03-10 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970310T090000', 'yearly')->interval(2)->count(10)->bymonth(array(1,2,3));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * DTSTART;TZID=US-Eastern:19980101T090000
 	 * RRULE:FREQ=YEARLY;UNTIL=20000131T090000Z;BYMONTH=1;BYDAY=SU,MO,TU,WE,TH,FR,SA
@@ -183,16 +183,16 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2000-01-29 09:00:00');
 		$results[] = new DateTime('2000-01-30 09:00:00');
 		$results[] = new DateTime('2000-01-31 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19980101T090000', 'yearly')->until('20000131T090000')->bymonth(array(1))->byday(array('SU','MO','TU','WE','TH','FR','SA'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Monday of week number 20 (where the default start of the week is Monday), forever:
 	 * DTSTART;TZID=US-Eastern:19970512T090000
@@ -211,17 +211,17 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2004-05-10 09:00:00');
 		$results[] = new DateTime('2005-05-16 09:00:00');
 		$results[] = new DateTime('2006-05-15 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970512T090000', 'yearly')->count(10)->byweekno(array(20))->byday(array('MO'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	 }
-	 
-	 /** 
+
+	 /**
 	  * Every Thursday in March, forever:
 	  * DTSTART;TZID=US-Eastern:19970313T090000
 	  * RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=TH
@@ -238,16 +238,16 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1999-03-04 09:00:00');
 		$results[] = new DateTime('1999-03-11 09:00:00');
 		$results[] = new DateTime('1999-03-18 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970313T090000', 'yearly')->count(10)->bymonth(array(3))->byday(array('TH'));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	 }
-	 
+
 	/**
 	 * Every Thursday, but only during June, July, and August, forever:
 	 * DTSTART;TZID=US-Eastern:19970605T090000
@@ -294,16 +294,16 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('1999-08-12 09:00:00');
 		$results[] = new DateTime('1999-08-19 09:00:00');
 		$results[] = new DateTime('1999-08-26 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970605T090000', 'yearly')->count(39)->byday(array('TH'))->bymonth(array(6,7,8));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every four years, the first Tuesday after a Monday in November, forever (U.S. Presidential Election day):
 	 * DTSTART;TZID=US-Eastern:19961105T090000
@@ -321,16 +321,16 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2024-11-05 09:00:00');
 		$results[] = new DateTime('2028-11-07 09:00:00');
 		$results[] = new DateTime('2032-11-02 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19961105T090000', 'yearly')->count(10)->interval(4)->bymonth(array(11))->byday(array('TU'))->bymonthday(array(2,3,4,5,6,7,8));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every third year on the 1st, 100th, and 200th day for 10 occurrences:
 	 * DTSTART;TZID=America/New_York:19970101T090000
@@ -348,16 +348,16 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2003-04-10 09:00:00');
 		$results[] = new DateTime('2003-07-19 09:00:00');
 		$results[] = new DateTime('2006-01-01 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('19970101T090000', 'yearly')->interval(3)->count(10)->byyearday(array(1,100,200));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 	/**
 	 * Every year on the -1th, -100th, and -200th day for 5 occurrences (checked via google calendar import below)
 	 * BEGIN:VCALENDAR
@@ -405,14 +405,14 @@ class When_Yearly_Test extends PHPUnit_Framework_TestCase
 		$results[] = new DateTime('2010-06-15 09:00:00');
 		$results[] = new DateTime('2011-12-31 09:00:00');
 		$results[] = new DateTime('2011-09-23 09:00:00');
-		
+
 		$r = new When();
 		$r->recur('20101231T090000', 'yearly')->count(5)->byyearday(array(-1, -100, -200));
-		
+
 		foreach($results as $result)
 		{
 			$this->assertEquals($result, $r->next());
 		}
 	}
-	
+
 }

--- a/When.php
+++ b/When.php
@@ -10,92 +10,94 @@
 class When
 {
 	protected $frequency;
-	
+
 	protected $start_date;
 	protected $try_date;
-	
+
 	protected $end_date;
-	
+
 	protected $gobymonth;
 	protected $bymonth;
-	
+
 	protected $gobyweekno;
 	protected $byweekno;
-	
+
 	protected $gobyyearday;
 	protected $byyearday;
-	
+
 	protected $gobymonthday;
 	protected $bymonthday;
-	
+
 	protected $gobyday;
 	protected $byday;
-	
+
 	protected $gobysetpos;
 	protected $bysetpos;
-		
+
 	protected $suggestions;
-	
+
 	protected $count;
 	protected $counter;
-	
+
 	protected $goenddate;
-	
+
 	protected $interval;
-	
+
 	protected $wkst;
-	
+
 	protected $valid_week_days;
 	protected $valid_frequency;
-		
+
+	protected $keep_first_month_day;
+
 	/**
 	 * __construct
 	 */
 	public function __construct()
 	{
 		$this->frequency = null;
-		
+
 		$this->gobymonth = false;
 		$this->bymonth = range(1,12);
-		
+
 		$this->gobymonthday = false;
 		$this->bymonthday = range(1,31);
-		
+
 		$this->gobyday = false;
 		// setup the valid week days (0 = sunday)
 		$this->byday = range(0,6);
-		
+
 		$this->gobyyearday = false;
 		$this->byyearday = range(0,366);
-		
+
 		$this->gobysetpos = false;
 		$this->bysetpos = range(1,366);
-		
+
 		$this->gobyweekno = false;
 		// setup the range for valid weeks
 		$this->byweekno = range(0,54);
-		
+
 		$this->suggestions = array();
-		
+
 		// this will be set if a count() is specified
 		$this->count = 0;
 		// how many *valid* results we returned
 		$this->counter = 0;
-		
+
 		// max date we'll return
 		$this->end_date = new DateTime('9999-12-31');
-		
+
 		// the interval to increase the pattern by
 		$this->interval = 1;
-		
+
 		// what day does the week start on? (0 = sunday)
 		$this->wkst = 0;
-		
+
 		$this->valid_week_days = array('SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA');
-		
+
 		$this->valid_frequency = array('SECONDLY', 'MINUTELY', 'HOURLY', 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY');
 	}
-	
+
 	/**
 	 * @param DateTime|string $start_date of the recursion - also is the first return value.
 	 * @param string $frequency of the recrusion, valid frequencies: secondly, minutely, hourly, daily, weekly, monthly, yearly
@@ -114,16 +116,16 @@ class When
 				$start_date = trim($start_date, 'Z');
 				$this->start_date = new DateTime($start_date);
 			}
-			
+
 			$this->try_date = clone $this->start_date;
 		}
 		catch(Exception $e)
 		{
 			throw new InvalidArgumentException('Invalid start date DateTime: ' . $e);
 		}
-		
+
 		$this->freq($frequency);
-		
+
 		return $this;
 	}
 
@@ -146,7 +148,7 @@ class When
 	{
 		// strip off a trailing semi-colon
 		$rrule = trim($rrule, ";");
-		
+
 		$parts = explode(";", $rrule);
 
 		foreach($parts as $part)
@@ -203,23 +205,23 @@ class When
 
 		return $this;
 	}
-	
+
 	//max number of items to return based on the pattern
 	public function count($count)
 	{
 		$this->count = (int)$count;
-		
+
 		return $this;
 	}
-	
+
 	// how often the recurrence rule repeats
 	public function interval($interval)
 	{
 		$this->interval = (int)$interval;
-		
+
 		return $this;
 	}
-	
+
 	// starting day of the week
 	public function wkst($day)
 	{
@@ -247,13 +249,13 @@ class When
 				$this->wkst = 6;
 				break;
 		}
-		
+
 		return $this;
 	}
-	
+
 	// max date
 	public function until($end_date)
-	{		
+	{
 		try
 		{
 			if(is_object($end_date))
@@ -271,72 +273,72 @@ class When
 		{
 			throw new InvalidArgumentException('Invalid end date DateTime: ' . $e);
 		}
-		
+
 		return $this;
 	}
 
 	public function bymonth($months)
-	{	
+	{
 		if(is_array($months))
 		{
 			$this->gobymonth = true;
 			$this->bymonth = $months;
 		}
-		
+
 		return $this;
 	}
-	
+
 	public function bymonthday($days)
-	{	
+	{
 		if(is_array($days))
 		{
 			$this->gobymonthday = true;
 			$this->bymonthday = $days;
 		}
-		
+
 		return $this;
 	}
-	
+
 	public function byweekno($weeks)
 	{
 		$this->gobyweekno = true;
-		
+
 		if(is_array($weeks))
 		{
 			$this->byweekno = $weeks;
 		}
-		
+
 		return $this;
 	}
-	
+
 	public function bysetpos($days)
 	{
 		$this->gobysetpos = true;
-		
+
 		if(is_array($days))
 		{
 			$this->bysetpos = $days;
 		}
-		
+
 		return $this;
 	}
-	
+
 	public function byday($days)
-	{		
+	{
 		$this->gobyday = true;
-		
+
 		if(is_array($days))
 		{
 			$this->byday = array();
 			foreach($days as $day)
 			{
 				$len = strlen($day);
-				
+
 				$as = '+';
-				
+
 				// 0 mean no occurence is set
 				$occ = 0;
-				
+
 				if($len == 3)
 				{
 					$occ = substr($day, 0, 1);
@@ -346,7 +348,7 @@ class When
 					$as = substr($day, 0, 1);
 					$occ = substr($day, 1, 1);
 				}
-				
+
 				if($as == '-')
 				{
 					$occ = '-' . $occ;
@@ -355,7 +357,7 @@ class When
 				{
 					$occ = '+' . $occ;
 				}
-				
+
 				$day = substr($day, -2, 2);
 				switch($day)
 				{
@@ -383,22 +385,22 @@ class When
 				}
 			}
 		}
-		
+
 		return $this;
 	}
-	
+
 	public function byyearday($days)
 	{
 		$this->gobyyearday = true;
-		
+
 		if(is_array($days))
 		{
 			$this->byyearday = $days;
 		}
-		
+
 		return $this;
 	}
-	
+
 	// this creates a basic list of dates to "try"
 	protected function create_suggestions()
 	{
@@ -426,15 +428,17 @@ class When
 				$interval = 'second';
 				break;
 		}
-					
+
 		$month_day = $this->try_date->format('j');
 		$month = $this->try_date->format('n');
 		$year = $this->try_date->format('Y');
-		
+
+
+
 		$timestamp = $this->try_date->format('H:i:s');
-					
+
 		if($this->gobysetpos)
-		{				
+		{
 			if($this->try_date == $this->start_date)
 			{
 				$this->suggestions[] = clone $this->try_date;
@@ -450,28 +454,28 @@ class When
 						foreach($_mdays as $_mday)
 						{
 							$date_time = new DateTime($year . '-' . $month . '-' . $_mday . ' ' . $timestamp);
-							
+
 							$occur = ceil($_mday / 7);
-							
+
 							$day_of_week = $date_time->format('l');
 							$dow_abr = strtoupper(substr($day_of_week, 0, 2));
-							
+
 							// set the day of the month + (positive)
 							$occur = '+' . $occur . $dow_abr;
 							$occur_zero = '+0' . $dow_abr;
-							
+
 							// set the day of the month - (negative)
 							$total_days = $date_time->format('t') - $date_time->format('j');
 							$occur_neg = '-' . ceil(($total_days + 1)/7) . $dow_abr;
-							
+
 							$day_from_end_of_month = $date_time->format('t') + 1 - $_mday;
-							
+
 							if(in_array($occur, $this->byday) || in_array($occur_zero, $this->byday) || in_array($occur_neg, $this->byday))
-							{								
+							{
 								$tmp_array[] = clone $date_time;
 							}
 						}
-						
+
 						if($_pos > 0)
 						{
 							$this->suggestions[] = clone $tmp_array[$_pos - 1];
@@ -480,7 +484,7 @@ class When
 						{
 							$this->suggestions[] = clone $tmp_array[count($tmp_array) + $_pos];
 						}
-						
+
 					}
 				}
 			}
@@ -492,7 +496,7 @@ class When
 				if($_day >= 0)
 				{
 					$_day--;
-					
+
 					$_time = strtotime('+' . $_day . ' days', mktime(0, 0, 0, 1, 1, $year));
 					$this->suggestions[] = new Datetime(date('Y-m-d', $_time) . ' ' . $timestamp);
 				}
@@ -504,10 +508,10 @@ class When
 					{
 						$year_day_neg = 366 + $_day;
 					}
-					
+
 					$_time = strtotime('+' . $year_day_neg . ' days', mktime(0, 0, 0, 1, 1, $year));
 					$this->suggestions[] = new Datetime(date('Y-m-d', $_time) . ' ' . $timestamp);
-				}					
+				}
 			}
 		}
 		// special case because for years you need to loop through the months too
@@ -520,10 +524,10 @@ class When
 				foreach($_mdays as $_mday)
 				{
 					$date_time = new DateTime($year . '-' . $_month . '-' . $_mday . ' ' . $timestamp);
-					
+
 					// get the week of the month (1, 2, 3, 4, 5, etc)
 					$week = $date_time->format('W');
-					
+
 					if($date_time >= $this->start_date && in_array($week, $this->byweekno))
 					{
 						$this->suggestions[] = clone $date_time;
@@ -538,16 +542,16 @@ class When
 		elseif($interval == "week")
 		{
 			$this->suggestions[] = clone $this->try_date;
-			
+
 			if($this->gobyday)
 			{
 				$week_day = $this->try_date->format('w');
-				
+
 				$days_in_month = $this->try_date->format('t');
-				
+
 				$overflow_count = 1;
 				$_day = $month_day;
-				
+
 				$run = true;
 				while($run)
 				{
@@ -563,9 +567,9 @@ class When
 						$tmp_date->modify('+1 month');
 						$overflow_count++;
 					}
-					
+
 					$week_day = $tmp_date->format('w');
-					
+
 					if($this->try_date == $this->start_date)
 					{
 						if($week_day == $this->wkst)
@@ -587,16 +591,15 @@ class When
 				}
 			}
 		}
-		elseif($this->gobyday || $interval == "month")
+		elseif($this->gobyday || ($this->gobymonthday && $interval == "month"))
 		{
 			$_mdays = range(1, date('t',mktime(0,0,0,$month,1,$year)));
 			foreach($_mdays as $_mday)
 			{
 				$date_time = new DateTime($year . '-' . $month . '-' . $_mday . ' ' . $timestamp);
-				
 				// get the week of the month (1, 2, 3, 4, 5, etc)
 				$week = $date_time->format('W');
-				
+
 				if($date_time >= $this->start_date && in_array($week, $this->byweekno))
 				{
 					$this->suggestions[] = clone $date_time;
@@ -608,18 +611,40 @@ class When
 			foreach($this->bymonth as $_month)
 			{
 				$date_time = new DateTime($year . '-' . $_month . '-' . $month_day . ' ' . $timestamp);
-				
+
 				if($date_time >= $this->start_date)
 				{
 					$this->suggestions[] = clone $date_time;
 				}
 			}
-		} 
-		else 
+		}
+		elseif($interval == "month")
+		{
+			// Keep track of the original day of the month that was used
+			if ($this->keep_first_month_day === null) {
+				$this->keep_first_month_day = $month_day;
+			}
+
+			$month_count = 1;
+			foreach($this->bymonth as $_month)
+			{
+				$date_time = new DateTime($year . '-' . $_month . '-' . $this->keep_first_month_day . ' ' . $timestamp);
+				if ($month_count == count($this->bymonth)) {
+					$this->try_date->modify('+1 year');
+				}
+
+				if($date_time >= $this->start_date)
+				{
+					$this->suggestions[] = clone $date_time;
+				}
+				$month_count++;
+			}
+		}
+		else
 		{
 			$this->suggestions[] = clone $this->try_date;
 		}
-		
+
 		if($interval == "month")
 		{
 			$this->try_date->modify('last day of ' . $this->interval . ' ' . $interval);
@@ -629,42 +654,42 @@ class When
 			$this->try_date->modify($this->interval . ' ' . $interval);
 		}
 	}
-	
+
 	public function valid_date($date)
 	{
 		$year = $date->format('Y');
 		$month = $date->format('n');
 		$day = $date->format('j');
-		
+
 		$year_day = $date->format('z') + 1;
-		
+
 		$year_day_neg = -366 + $year_day;
 		$leap_year = $date->format('L');
 		if($leap_year == 1)
 		{
 			$year_day_neg = -367 + $year_day;
 		}
-		
+
 		// this is the nth occurence of the date
 		$occur = ceil($day / 7);
-		
+
 		$week = $date->format('W');
-		
+
 		$day_of_week = $date->format('l');
 		$dow_abr = strtoupper(substr($day_of_week, 0, 2));
-		
+
 		// set the day of the month + (positive)
 		$occur = '+' . $occur . $dow_abr;
 		$occur_zero = '+0' . $dow_abr;
-		
+
 		// set the day of the month - (negative)
 		$total_days = $date->format('t') - $date->format('j');
 		$occur_neg = '-' . ceil(($total_days + 1)/7) . $dow_abr;
-		
+
 		$day_from_end_of_month = $date->format('t') + 1 - $day;
-		
-		if(in_array($month, $this->bymonth) && 
-		   (in_array($occur, $this->byday) || in_array($occur_zero, $this->byday) || in_array($occur_neg, $this->byday)) && 
+
+		if(in_array($month, $this->bymonth) &&
+		   (in_array($occur, $this->byday) || in_array($occur_zero, $this->byday) || in_array($occur_neg, $this->byday)) &&
 		   in_array($week, $this->byweekno) &&
 		   (in_array($day, $this->bymonthday) || in_array(-$day_from_end_of_month, $this->bymonthday)) &&
 		   (in_array($year_day, $this->byyearday) || in_array($year_day_neg, $this->byyearday)))
@@ -679,7 +704,7 @@ class When
 
 	// return the next valid DateTime object which matches the pattern and follows the rules
 	public function next()
-	{		
+	{
 		// check the counter is set
 		if($this->count !== 0)
 		{
@@ -688,25 +713,25 @@ class When
 				return false;
 			}
 		}
-		
+
 		// create initial set of suggested dates
 		if(count($this->suggestions) === 0)
 		{
 			$this->create_suggestions();
 		}
-		
+
 		// loop through the suggested dates
 		while(count($this->suggestions) > 0)
 		{
 			// get the first one on the array
 			$try_date = array_shift($this->suggestions);
-			
+
 			// make sure the date doesn't exceed the max date
 			if($try_date > $this->end_date)
 			{
 				return false;
 			}
-			
+
 			// make sure it falls within the allowed days
 			if($this->valid_date($try_date) === true)
 			{


### PR DESCRIPTION
Rrule: FREQ=MONTHLY without extraneous rules was being treated incorrectly and would return a recurrence set. This is a hacky fix for an issue reported 2 years ago... Added a few PHPUnit tests for FREQ only tests: DAILY, MONTHLY, YEARLY. 

Also... ended up killing those pesky line spaces.
