### PR TITLE
Fix for yearly intervals not getting default offsets from the start date if none present

### DIFF
--- a/src/When/When.php
+++ b/src/When/When.php
@@ -750,7 +750,7 @@ class When extends \DateTime
 
         if ($this->freq === "yearly")
         {
-            if (!isset($this->bymonthdays) && !isset($this->bymonths))
+            if (!isset($this->bymonthdays) && !isset($this->bydays) && !isset($this->bymonths) && !isset($this->byyeardays) && !isset($this->byweeknos))
             {
             	$this->bymonths = array($this->startDate->format('n'));
                 $this->bymonthdays = array($this->startDate->format('j'));

--- a/src/When/When.php
+++ b/src/When/When.php
@@ -747,6 +747,15 @@ class When extends \DateTime
                 $this->bydays = array("0" . $dayOfWeekAbr);
             }
         }
+
+        if ($this->freq === "yearly")
+        {
+            if (!isset($this->bymonthdays) && !isset($this->bymonths))
+            {
+            	$this->bymonths = array($this->startDate->format('n'));
+                $this->bymonthdays = array($this->startDate->format('j'));
+            }
+        }
     }
 
     protected static function createItemsList($list, $delimiter)


### PR DESCRIPTION
May only be required in tandem with [#20](https://github.com/tplaner/When/pull/20)
