### PR TITLE
Added support for Yearly repeaters

### DIFF
--- a/src/When/When.php
+++ b/src/When/When.php
@@ -747,6 +747,18 @@ class When extends \DateTime
                 $this->bydays = array("0" . $dayOfWeekAbr);
             }
         }
+
+        if ($this->freq === "yearly")
+        {
+            if (isset($this->bymonthdays))
+            {
+                $s = $this->startDate;
+                $this->startDate = $s->setDate($s->format('Y'), $s->format('m'), $this->bymonthdays[0]);
+            }
+        }
+     }
+
+     protected static function createItemsList($list, $delimiter)
     }
 
     protected static function createItemsList($list, $delimiter)


### PR DESCRIPTION
There seemed to be an issue with an ical file like:

RRULE:FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=17;COUNT=10

When.php was returning no occurrences.  After adding these lines the result is now:

{"occurrences":[{"date":"20151217T000000","type":"rrule"},{"date":"20161217T000000","type":"rrule"},{"date":"20171217T000000","type":"rrule"},{"date":"20181217T000000","type":"rrule"},{"date":"20191217T000000","type":"rrule"},{"date":"20201217T000000","type":"rrule"},{"date":"20211217T000000","type":"rrule"},{"date":"20221217T000000","type":"rrule"},{"date":"20231217T000000","type":"rrule"},{"date":"20241217T000000","type":"rrule"}],"batch":{"start":0,"end":13,"batch_size":13,"batches":1,"currentBatch":1}}
