### PR TITLE
Fix Valid::byFreqValid() Method Signature

### DIFF
--- a/src/Valid.php
+++ b/src/Valid.php
@@ -66,7 +66,7 @@ class Valid
         return true;
     }
 
-    public function byFreqValid($freq, $byweeknos, $byyeardays, $bymonthdays)
+    public static function byFreqValid($freq, $byweeknos, $byyeardays, $bymonthdays)
     {
         if (isset($byweeknos) && $freq !== "yearly")
         {


### PR DESCRIPTION
Method is called statically on line 675 of the When class.