### PR TITLE
#38 - Developers may now specify the error handling behavior of `InvalidStartDate`

### DIFF
--- a/src/When.php
+++ b/src/When.php
@@ -4,6 +4,11 @@ namespace When;
 
 class When extends \DateTime
 {
+    const EXCEPTION = 0;
+    const WARNING = 1;
+    const IGNORE = 2;
+
+    public $invalidStartDateErrorLevel = self::EXCEPTION;
     public $startDate;
     public $freq;
     public $until;
@@ -394,7 +399,17 @@ class When extends \DateTime
         }
         else
         {
-            throw new InvalidStartDate();
+            switch ($this->invalidStartDateErrorLevel) {
+                case self::WARNING:
+                    trigger_error('InvalidStartDate: startDate is outside the bounds of the occurrence parameters.');
+                    break;
+                case self::IGNORE:
+                    break;
+                case self::EXCEPTION:
+                default:
+                    throw new InvalidStartDate();
+                    break;
+            }
         }
 
         while ($dateLooper < $this->until && count($this->occurrences) < $this->count)

--- a/src/When.php
+++ b/src/When.php
@@ -5,10 +5,10 @@ namespace When;
 class When extends \DateTime
 {
     const EXCEPTION = 0;
-    const WARNING = 1;
+    const NOTICE = 1;
     const IGNORE = 2;
 
-    public $invalidStartDateErrorLevel = self::EXCEPTION;
+    public $RFC5545_COMPLIANT = self::EXCEPTION;
     public $startDate;
     public $freq;
     public $until;
@@ -399,8 +399,8 @@ class When extends \DateTime
         }
         else
         {
-            switch ($this->invalidStartDateErrorLevel) {
-                case self::WARNING:
+            switch ($this->RFC5545_COMPLIANT) {
+                case self::NOTICE:
                     trigger_error('InvalidStartDate: startDate is outside the bounds of the occurrence parameters.');
                     break;
                 case self::IGNORE:

--- a/tests/WhenCoreTest.php
+++ b/tests/WhenCoreTest.php
@@ -629,6 +629,63 @@ class WhenCoreTest extends \PHPUnit_Framework_TestCase {
         $test = new When;
         $test->count('weekly');
     }
+
+    /**
+     * @expectedException \When\InvalidStartDate
+     */
+    public function testGenerateOccurrencesErrorException()
+    {
+        $test = new When;
+
+        $test->startDate(new DateTime("19970905T090000"))
+            ->rrule("FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3")
+            ->generateOccurrences();
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error_Notice
+     */
+    public function testGenerateOccurrencesErrorNotice()
+    {
+        $results[] = new DateTime('1997-10-07 09:00:00');
+        $results[] = new DateTime('1997-11-06 09:00:00');
+
+        $test = new When;
+
+        $test->invalidStartDateErrorLevel = When::WARNING;
+
+        $test->startDate(new DateTime("19970905T090000"))
+            ->rrule("FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3")
+            ->generateOccurrences();
+
+        $occurrences = $test->occurrences;
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
+
+    public function testGenerateOccurrencesErrorIgnored()
+    {
+        $results[] = new DateTime('1997-10-07 09:00:00');
+        $results[] = new DateTime('1997-11-06 09:00:00');
+
+        $test = new When;
+
+        $test->invalidStartDateErrorLevel = When::IGNORE;
+
+        $test->startDate(new DateTime("19970905T090000"))
+            ->rrule("FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3")
+            ->generateOccurrences();
+
+        $occurrences = $test->occurrences;
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
 }
 
 class FakeObject {}

--- a/tests/WhenCoreTest.php
+++ b/tests/WhenCoreTest.php
@@ -652,7 +652,7 @@ class WhenCoreTest extends \PHPUnit_Framework_TestCase {
 
         $test = new When;
 
-        $test->invalidStartDateErrorLevel = When::WARNING;
+        $test->RFC5545_COMPLIANT = When::NOTICE;
 
         $test->startDate(new DateTime("19970905T090000"))
             ->rrule("FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3")
@@ -673,7 +673,7 @@ class WhenCoreTest extends \PHPUnit_Framework_TestCase {
 
         $test = new When;
 
-        $test->invalidStartDateErrorLevel = When::IGNORE;
+        $test->RFC5545_COMPLIANT = When::IGNORE;
 
         $test->startDate(new DateTime("19970905T090000"))
             ->rrule("FREQ=MONTHLY;COUNT=3;BYDAY=TU,WE,TH;BYSETPOS=3")


### PR DESCRIPTION
Related to #38 

This PR was created due to an internal need for our application to generate occurrences without the requirement that the start date match the first occurrence. This PR maintains prior behavior and introduces the option of generating a E_NOTIFY level event or IGNORE the error completely.