### PR TITLE
Fixes issue #45

### DIFF
--- a/src/When.php
+++ b/src/When.php
@@ -567,8 +567,9 @@ class When extends \DateTime
                 {
                     $startWeekDay = clone $this->startDate;
                     $startWeekDay->modify("next " . $wkst);
+                    $startWeekDay->setTime($dateLooper->format('H'), $dateLooper->format('i'), $dateLooper->format('s'));
 
-                    $daysLeft = $dateLooper->diff($startWeekDay)->format("%a") + 1;
+                    $daysLeft = (int) $dateLooper->diff($startWeekDay)->format("%a");
 
                     $startWeekDay->modify("last " . $wkst);
                 }

--- a/tests/WhenWeeklyRruleTest.php
+++ b/tests/WhenWeeklyRruleTest.php
@@ -283,7 +283,6 @@ class WhenWeeklyRruleTest extends PHPUnit_Framework_TestCase
     {
         $results[] = new DateTime('2014-02-10 00:00:00');
         $results[] = new DateTime('2014-02-11 00:00:00');
-        $results[] = new DateTime('2014-02-17 00:00:00');
         $results[] = new DateTime('2014-02-24 00:00:00');
         $results[] = new DateTime('2014-02-25 00:00:00');
         $results[] = new DateTime('2014-03-10 00:00:00');

--- a/tests/WhenWeeklyTest.php
+++ b/tests/WhenWeeklyTest.php
@@ -305,4 +305,46 @@ class WhenWeeklyTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($result, $occurrences[$key]);
         }
     }
+
+    /**
+     * Every other week - forever:
+     * DTSTART;TZID=America/New_York:19970902T000000
+     * RRULE:FREQ=WEEKLY;INTERVAL=2;WKST=TU
+     *
+     * Weekstart meets first occurrence,
+     * time is midnight.
+     *
+     * @see https://github.com/tplaner/When/issues/45
+     */
+    function testWeeklyNine()
+    {
+        $results[] = new DateTime('1997-09-02 00:00:00');
+        $results[] = new DateTime('1997-09-16 00:00:00');
+        $results[] = new DateTime('1997-09-30 00:00:00');
+        $results[] = new DateTime('1997-10-14 00:00:00');
+        $results[] = new DateTime('1997-10-28 00:00:00');
+        $results[] = new DateTime('1997-11-11 00:00:00');
+        $results[] = new DateTime('1997-11-25 00:00:00');
+        $results[] = new DateTime('1997-12-09 00:00:00');
+        $results[] = new DateTime('1997-12-23 00:00:00');
+        $results[] = new DateTime('1998-01-06 00:00:00');
+        $results[] = new DateTime('1998-01-20 00:00:00');
+        $results[] = new DateTime('1998-02-03 00:00:00');
+        $results[] = new DateTime('1998-02-17 00:00:00');
+
+        $r = new When();
+        $r->startDate(new \DateTime('1997-09-02 00:00:00'))
+            ->freq('weekly')
+            ->interval(2)
+            ->wkst('TU')
+            ->count(13)
+            ->generateOccurrences();
+
+        $occurrences = $r->occurrences;
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
 }


### PR DESCRIPTION
Weekly recurrences with an interval other than 1 were not computed correctly when
- Weekstart matched first occurrence and
- Time was 00:00:00

Also one test (testNman12WeeklyBug) was broken (wrong assertions).

Signed-off-by: Markus Mahner <mm@it-agenten.com>