### PR TITLE
Add getOccurrencesBetween, getNextOccurrence, getPrevOccurrence

### DIFF
--- a/src/When.php
+++ b/src/When.php
@@ -366,24 +366,28 @@ class When extends \DateTime
                 $numPeriods = ($numYears * 12) + $numMonths;
                 break;
             case 'weekly':
-                $sinceStart = $date->diff($this->startDate); // Note we "expanded" startDate already. 
+                $sinceStart = $date->diff($this->startDate); // Note we "expanded" startDate already.
                 $numPeriods = ceil($sinceStart->days / 7);
                 break;
             case 'daily':
+                $sinceStart = $date->diff($this->startDate); // Note we "expanded" startDate already.
                 $numPeriods = $sinceStart->days;
                 break;
             case 'hourly':
+                $sinceStart = $date->diff($this->startDate); // Note we "expanded" startDate already.
                 $numDays = $sinceStart->days;
                 $numHours = $sinceStart->h;
                 $numPeriods = (24 * $numDays) + $numHours;
                 break;
             case 'minutely':
+                $sinceStart = $date->diff($this->startDate); // Note we "expanded" startDate already.
                 $numDays = $sinceStart->days;
                 $numHours = $sinceStart->h;
                 $numMinutes = $sinceStart->i;
                 $numPeriods = (60 * ((24 * $numDays) + $numHours)) + $numMinutes;
                 break;
             case 'secondly':
+                $sinceStart = $date->diff($this->startDate); // Note we "expanded" startDate already.
                 $numDays = $sinceStart->days;
                 $numHours = $sinceStart->h;
                 $numMinutes = $sinceStart->i;
@@ -521,7 +525,7 @@ class When extends \DateTime
      */
     private function adjustStartDateByRule() {
         if (($this->freq == 'weekly') && (isset($this->bydays))) {
-            $this->startDate(self::expandWeeklyStartDate($this->startDate, $this->freq, $this->wkst, $this->bydays));
+            $this->startDate(self::expandWeeklyStartDate($this->startDate, $this->wkst, $this->bydays));
         }
     }
 
@@ -531,17 +535,17 @@ class When extends \DateTime
      * and a BYDAY rule part is specified." -- RFC 5545
      * See http://stackoverflow.com/questions/5750586/determining-occurrences-from-icalendar-rrule-that-expands
      */
-    public static function expandWeeklyStartDate($startDate, $freq, $wkst, $bydays) {
+    public static function expandWeeklyStartDate($startDate, $wkst, $bydays) {
         $wkst = self::abbrevToDayName($wkst);
         $startWeekDay = clone $startDate;
-        // Get the week start for this rule.
+
+        // Get first $wkst in the same week as $startWeekDay.
         $startWeekDay->modify("next " . $wkst);
         $startWeekDay->modify("last " . $wkst);
 
         // Find the next day that matches $bydays
         $startWeekDay_abbrev = substr($startWeekDay->format('D'), 0, 2);
         $best_candidate = clone $startWeekDay;
-        $best_candidate->modify("next " . $wkst); // Initialize it out to next week.
         foreach ($bydays as $abbrev) {
             $abbrev = substr($abbrev, 1, 2);
             if ($abbrev == $startWeekDay_abbrev) {

--- a/src/When.php
+++ b/src/When.php
@@ -448,6 +448,12 @@ class When extends \DateTime
     // Get occurrences between two DateTimes, exclusive. Does not modify $this.
     public function getOccurrencesBetween($startDate, $endDate, $limit=NULL) {
 
+        // Enforce consistent time zones. Date comparisons don't require them, but +P1D loop does.
+        if ($tz = $this->getTimeZone()) {
+            $startDate->setTimeZone($tz);
+            $endDate->setTimeZone($tz);
+        }
+
         $occurrences = array();
 
         if ($endDate <= $startDate) {

--- a/src/When.php
+++ b/src/When.php
@@ -382,6 +382,8 @@ class When extends \DateTime
                 return false;
             }
         }
+
+        return true;
     }
 
     // Get occurrences between two DateTimes, exclusive. Does not modify $this.
@@ -393,7 +395,7 @@ class When extends \DateTime
             return $occurrences;
         }
 
-        self::prepareDateElements(FALSE);
+        self::prepareDateElements(false);
 
         // Trim to the defined range of this When:
         if ($this->startDate > $startDate) {
@@ -422,9 +424,15 @@ class When extends \DateTime
         }
 
         $dateLooper = clone $startDate;
+        $firstDate = true;
         while ($dateLooper < $endDate) {
             if ($this->occursOn($dateLooper)) {
                 foreach ($this->generateTimeOccurrences($dateLooper) as $occur) {
+                    if ($firstDate) { // We might pick up an earlier time the same day. 
+                        if ($occur < $startDate) {
+                            continue;
+                        }
+                    }
                     $occurrences[] = $occur;
                     if ($max_occurrences && ($max_occurrences <= count($occurrences))) {
                         return array_slice($occurrences, 0, $max_occurrences);
@@ -432,11 +440,14 @@ class When extends \DateTime
                 }
             }
             $dateLooper->add(new \DateInterval('P1D'));
+            $firstDate = false;
         }
         return $occurrences;
     }
 
-    public function getNextOccurrence($occurDate, $strictly_after=TRUE) {
+    public function getNextOccurrence($occurDate, $strictly_after=true) {
+
+        self::prepareDateElements(false);
 
         if (! $strictly_after) {
             if ($this->occursOn($occurDate) && $this->occursAt($occurDate)) {
@@ -456,17 +467,19 @@ class When extends \DateTime
                 return $candidate;
             }
         }
-        return FALSE;
+        return false;
     }
 
     public function getPrevOccurrence($occurDate) {
+
+        self::prepareDateElements(false);
 
         $startDate = $this->startDate;
         $candidates = $this->getOccurrencesBetween($startDate, $occurDate);
         if (count($candidates)) {
             return array_pop($candidates);
         }
-        return FALSE;
+        return false;
     }
 
     public function generateOccurrences()
@@ -761,7 +774,7 @@ class When extends \DateTime
     }
 
     // If $limitRange is true, $this->count and $this->until will be set if not already set.
-    protected function prepareDateElements($limitRange=TRUE)
+    protected function prepareDateElements($limitRange=true)
     {
         // if the interval isn't set, set it.
         if (!isset($this->interval))

--- a/src/When.php
+++ b/src/When.php
@@ -352,17 +352,21 @@ class When extends \DateTime
 
         // If there is an interval != 1, check whether this is an nth period.
         if ($this->interval > 1) {
-            $sinceStart = $date->diff($this->startDate);
             switch ($this->freq) {
             case 'yearly':
+                $start = new \DateTime($this->startDate->format("Y-1-1\TH:i:sP"));
+                $sinceStart = $date->diff($start);
                 $numPeriods = $sinceStart->y;
                 break;
             case 'monthly':
+                $start = new \DateTime($this->startDate->format("Y-m-1\TH:i:sP"));
+                $sinceStart = $date->diff($start);
                 $numYears = $sinceStart->y;
                 $numMonths = $sinceStart->m;
                 $numPeriods = ($numYears * 12) + $numMonths;
                 break;
             case 'weekly':
+                $sinceStart = $date->diff($this->startDate); // Note we "expanded" startDate already. 
                 $numPeriods = ceil($sinceStart->days / 7);
                 break;
             case 'daily':

--- a/src/When.php
+++ b/src/When.php
@@ -520,7 +520,7 @@ class When extends \DateTime
         return count($this->getOccurrencesBetween($this->startDate, $date));
     }
 
-    private function abbrevToDayName($abbrev) {
+    private static function abbrevToDayName($abbrev) {
         $daynames = array('su' => 'Sunday',
                           'mo' => 'Monday',
                           'tu' => 'Tuesday',

--- a/src/When.php
+++ b/src/When.php
@@ -397,19 +397,12 @@ class When extends \DateTime
 
         self::prepareDateElements(false);
 
-        // Trim to the defined range of this When:
-        if ($this->startDate > $startDate) {
-            $startDate = clone $this->startDate;
-        }
-        if ($this->until && ($this->until < $endDate)) {
-            $endDate = clone $this->until;
-        }
+        list($startDate, $endDate) = $this->findDateRangeOverlap($startDate, $endDate);
 
         // If we have a defined $count, we need to test from $this->startDate to ensure we stop at $count.
         if ($this->count and ($startDate > $this->startDate)) {
-            $max_occurrences = $this->count - count($this->getOccurrencesBetween(clone $this->startDate,
-                                                                                 clone $startDate));
-            if ($max_occurrences == 0) {
+            $max_occurrences = $this->count - $this->countOccurrencesBefore($startDate);
+            if ($max_occurrences <= 0) {
                 return $occurrences;
             }
         }
@@ -443,6 +436,21 @@ class When extends \DateTime
             $firstDate = false;
         }
         return $occurrences;
+    }
+
+    private function findDateRangeOverlap($startDate, $endDate) {
+        // Trim to the defined range of this When:
+        if ($this->startDate > $startDate) {
+            $startDate = clone $this->startDate;
+        }
+        if ($this->until && ($this->until < $endDate)) {
+            $endDate = clone $this->until;
+        }
+        return array($startDate, $endDate);
+    }
+
+    private function countOccurrencesBefore($date) {
+        return count($this->getOccurrencesBetween($this->startDate, $date));
     }
 
     public function getNextOccurrence($occurDate, $strictly_after=true) {

--- a/tests/WhenNextPrevTest.php
+++ b/tests/WhenNextPrevTest.php
@@ -90,5 +90,27 @@ class WhenNextPrevTest extends PHPUnit_Framework_TestCase
         
 
     /* Test getting previous occurrence */
+    function testGetPrevOccurrenceFromLastOccurence() {
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY")
+          ->until(new DateTime("19971104T090000"));
+
+        $expected = new DateTime("1997-10-28 09:00:00");
+
+        $result = $r->getPrevOccurrence(new DateTime("19971104T090000"));
+        $this->assertEquals($expected, $result);
+    }
+
+    /* Test that getting previous occurrence from the first returns FALSE */
+    function testGetPrevOccurrenceFromFirstOccurence() {
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY")
+          ->until(new DateTime("19971104T090000"));
+
+        $result = $r->getPrevOccurrence(new DateTime("19970902T090000"));
+        $this->assertFalse($result);
+    }
 
 }

--- a/tests/WhenNextPrevTest.php
+++ b/tests/WhenNextPrevTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use When\When;
+
+class WhenNextPrevTest extends PHPUnit_Framework_TestCase
+{
+    
+    /**
+     * Note: for this recurrence ...
+     *   $r = new When(); 
+     *   $r->startDate(new DateTime("19970902T090000")) 
+     *     ->rrule("FREQ=WEEKLY");
+     *
+     * The first few dates are:
+     *
+     *  $results[] = new DateTime('1997-09-02 09:00:00');
+     *  $results[] = new DateTime('1997-09-09 09:00:00');
+     *  $results[] = new DateTime('1997-09-16 09:00:00');
+     *  $results[] = new DateTime('1997-09-23 09:00:00');
+     *  $results[] = new DateTime('1997-09-30 09:00:00');
+     *  $results[] = new DateTime('1997-10-07 09:00:00');
+     *  $results[] = new DateTime('1997-10-14 09:00:00');
+     *  $results[] = new DateTime('1997-10-21 09:00:00');
+     *  $results[] = new DateTime('1997-10-28 09:00:00');
+     *  $results[] = new DateTime('1997-11-04 09:00:00');
+     */
+
+    /* Test getting next occurrence */
+    function testGetNextOccurrence() {
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $expected = new DateTime('1997-09-23 09:00:00');
+        $result = $r->getNextOccurrence(new DateTime("19970917T090000"));
+        $this->assertEquals($expected, $result);
+
+    }
+
+    /* Test getting next occurrence, using $strictly_after=FALSE with date in recurrence  */
+    function testGetNextOccurrenceNotStrictlyAfterMatchingDateTime() {
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $expected = new DateTime('1997-09-16 09:00:00');
+        $result = $r->getNextOccurrence(new DateTime("19970916T090000"), FALSE);
+        $this->assertEquals($expected, $result);
+
+    }
+
+    /* Test getting next occurrence, using $strictly_after=FALSE with date in recurrence, time not. */
+    function testGetNextOccurrenceNotStrictlyAfterMatchingDateMismatchedTime() {
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $expected = new DateTime('1997-09-23 09:00:00');
+        $result = $r->getNextOccurrence(new DateTime("19970916T093000"), FALSE);
+        $this->assertEquals($expected, $result);
+
+    }
+
+    /* Test getting next occurrence, using $strictly_after=TRUE (default)  with date in recurrence  */
+    function testGetNextOccurrenceStrictlyAfterMatchingDate() {
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $expected = new DateTime('1997-09-23 09:00:00');
+        $result = $r->getNextOccurrence(new DateTime("19970916T090000"));
+        $this->assertEquals($expected, $result);
+
+    }
+
+    /* Test getting next occurence on last occurrence */
+    function testGetNextOccurrenceFromLastOccurence() {
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY")
+          ->until(new DateTime("19971104T090000"));
+
+        $result = $r->getNextOccurrence(new DateTime("19971104T090000"));
+        $this->assertFalse($result);
+    }
+        
+
+    /* Test getting previous occurrence */
+
+}

--- a/tests/WhenOccurrencesBetweenTest.php
+++ b/tests/WhenOccurrencesBetweenTest.php
@@ -1,0 +1,214 @@
+<?php
+
+use When\When;
+
+class WhenOccurrencesBetweenTest extends PHPUnit_Framework_TestCase
+{
+
+    /* Get slices of an unbounded weekly recurrence */
+    function testGetWeeklyOccurrencesBetweenEarlySlice() {
+        $results = array();
+        $results[] = new DateTime('1997-09-02 09:00:00');
+        $results[] = new DateTime('1997-09-09 09:00:00');
+        $results[] = new DateTime('1997-09-16 09:00:00');
+        $results[] = new DateTime('1997-09-23 09:00:00');
+        $results[] = new DateTime('1997-09-30 09:00:00');
+        $results[] = new DateTime('1997-10-07 09:00:00');
+        $results[] = new DateTime('1997-10-14 09:00:00');
+        $results[] = new DateTime('1997-10-21 09:00:00');
+        $results[] = new DateTime('1997-10-28 09:00:00');
+        $results[] = new DateTime('1997-11-04 09:00:00');
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('1997-09-02 09:00:00'),
+        new DateTime('1997-11-04 09:01:00'));
+
+        foreach ($results as $key => $result) {
+             $this->assertEquals($result, $occurrences[$key]); 
+        }
+    }
+
+    /* Get slices of an unbounded weekly recurrence */
+    function testGetWeeklyOccurrencesBetweenLaterSlice() {
+
+        $results = array();
+        $results[] = new DateTime('2016-01-26 09:00:00');
+        $results[] = new DateTime('2016-02-02 09:00:00');
+        $results[] = new DateTime('2016-02-09 09:00:00');
+        $results[] = new DateTime('2016-02-16 09:00:00');
+        $results[] = new DateTime('2016-02-23 09:00:00');
+        $results[] = new DateTime('2016-03-01 09:00:00');
+        $results[] = new DateTime('2016-03-08 09:00:00');
+        $results[] = new DateTime('2016-03-15 09:00:00');
+        $results[] = new DateTime('2016-03-22 09:00:00');
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('2016-01-25 09:00:00'),
+        new DateTime('2016-03-22 09:01:00'));
+
+        foreach ($results as $key => $result) {
+             $this->assertEquals($result, $occurrences[$key]); 
+        }
+    }
+
+
+    /* Get a slice of an unbounded recurrence, with a limit */
+    function testGetWeeklyOccurrencesBetweenEarlySliceWithLimit() {
+        $results = array();
+        $results[] = new DateTime('1997-09-02 09:00:00');
+        $results[] = new DateTime('1997-09-09 09:00:00');
+        $results[] = new DateTime('1997-09-16 09:00:00');
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('1997-09-02 09:00:00'),
+        new DateTime('1997-11-04 09:01:00'), 3); 
+
+        foreach ($results as $key => $result) {
+             $this->assertEquals($result, $occurrences[$key]); 
+        }
+    }
+
+
+    function testGetWeeklyOccurrenceWindowBeforeStartDate() {
+        $results = array();
+        $results[] = new DateTime('1997-09-02 09:00:00');
+        $results[] = new DateTime('1997-09-09 09:00:00');
+        $results[] = new DateTime('1997-09-16 09:00:00');
+        $results[] = new DateTime('1997-09-23 09:00:00');
+        $results[] = new DateTime('1997-09-30 09:00:00');
+        $results[] = new DateTime('1997-10-07 09:00:00');
+        $results[] = new DateTime('1997-10-14 09:00:00');
+        $results[] = new DateTime('1997-10-21 09:00:00');
+        $results[] = new DateTime('1997-10-28 09:00:00');
+        $results[] = new DateTime('1997-11-04 09:00:00');
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('1987-09-02 09:00:00'),
+        new DateTime('1997-11-04 09:01:00'));
+
+        foreach ($results as $key => $result) {
+             $this->assertEquals($result, $occurrences[$key]); 
+        }
+    }
+
+
+    /* Test use of until date on bounded occurrence */
+    function testGetWeeklyOccurrenceWindowAfterUntilDate() {
+        $results = array();
+        $results[] = new DateTime('1997-09-02 09:00:00');
+        $results[] = new DateTime('1997-09-09 09:00:00');
+        $results[] = new DateTime('1997-09-16 09:00:00');
+        $results[] = new DateTime('1997-09-23 09:00:00');
+        $results[] = new DateTime('1997-09-30 09:00:00');
+        $results[] = new DateTime('1997-10-07 09:00:00');
+        $results[] = new DateTime('1997-10-14 09:00:00');
+        $results[] = new DateTime('1997-10-21 09:00:00');
+        $results[] = new DateTime('1997-10-28 09:00:00');
+        $results[] = new DateTime('1997-11-04 09:00:00');
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY")
+          ->until(new DateTime("19971105T090000"));;
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('1997-09-02 09:00:00'),
+        new DateTime('2007-11-04 09:01:00'));
+
+        $this->assertEquals(count($results), count($occurrences));
+        foreach ($results as $key => $result) {
+             $this->assertEquals($result, $occurrences[$key]); 
+        }
+    }
+
+    /* Test use of count on bounded occurrence */
+    function testGetWeeklyOccurrenceWindowBoundedByCount() {
+        $results = array();
+        $results[] = new DateTime('1997-09-02 09:00:00');
+        $results[] = new DateTime('1997-09-09 09:00:00');
+        $results[] = new DateTime('1997-09-16 09:00:00');
+        $results[] = new DateTime('1997-09-23 09:00:00');
+        $results[] = new DateTime('1997-09-30 09:00:00');
+        $results[] = new DateTime('1997-10-07 09:00:00');
+        $results[] = new DateTime('1997-10-14 09:00:00');
+        $results[] = new DateTime('1997-10-21 09:00:00');
+        $results[] = new DateTime('1997-10-28 09:00:00');
+        $results[] = new DateTime('1997-11-04 09:00:00');
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY")
+          ->count(10);
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('1997-09-02 09:00:00'),
+        new DateTime('2007-11-04 09:01:00'));
+
+        $this->assertEquals(count($results), count($occurrences));
+        foreach ($results as $key => $result) {
+             $this->assertEquals($result, $occurrences[$key]); 
+        }
+    }
+
+    /* Test use of count on bounded occurrence with window starting after recurrence start*/
+    function testGetWeeklyOccurrenceWindowCountAndStartDate() {
+        $results = array();
+        $results[] = new DateTime('1997-09-23 09:00:00');
+        $results[] = new DateTime('1997-09-30 09:00:00');
+        $results[] = new DateTime('1997-10-07 09:00:00');
+        $results[] = new DateTime('1997-10-14 09:00:00');
+        $results[] = new DateTime('1997-10-21 09:00:00');
+        $results[] = new DateTime('1997-10-28 09:00:00');
+        $results[] = new DateTime('1997-11-04 09:00:00');
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY")
+          ->count(10);
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('1997-09-23 09:00:00'),
+        new DateTime('2007-11-04 09:01:00'));
+
+        $this->assertEquals(count($results), count($occurrences));
+        foreach ($results as $key => $result) {
+             $this->assertEquals($result, $occurrences[$key]); 
+        }
+    }
+
+    /* Test use of count on bounded occurrence, where no events match window */
+    function testGetWeeklyOccurrenceWindowCountAndStartDateNoResults() {
+
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY")
+          ->count(10);
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('1997-11-05 09:00:00'),
+        new DateTime('2007-11-04 09:01:00'));
+
+        $this->assertEquals(0, count($occurrences));
+    }
+
+    /* Empty results on backwards date range */
+    function testGetWeeklyOccurrencesBackwardsDateRange() {
+        $r = new When(); 
+        $r->startDate(new DateTime("19970902T090000")) 
+          ->rrule("FREQ=WEEKLY");
+        
+        $occurrences = $r->getOccurrencesBetween(new DateTime('1997-11-04 09:01:00'),
+        new DateTime('1997-09-02 09:00:00')); 
+
+        $this->assertEquals(0, count($occurrences));
+    }
+
+}

--- a/tests/WhenWeeklyRruleTest.php
+++ b/tests/WhenWeeklyRruleTest.php
@@ -283,7 +283,7 @@ class WhenWeeklyRruleTest extends PHPUnit_Framework_TestCase
     {
         $results[] = new DateTime('2014-02-10 00:00:00');
         $results[] = new DateTime('2014-02-11 00:00:00');
-        $results[] = new DateTime('2014-02-17 00:00:00');
+        // $results[] = new DateTime('2014-02-17 00:00:00'); // Why was this here? 
         $results[] = new DateTime('2014-02-24 00:00:00');
         $results[] = new DateTime('2014-02-25 00:00:00');
         $results[] = new DateTime('2014-03-10 00:00:00');
@@ -291,6 +291,7 @@ class WhenWeeklyRruleTest extends PHPUnit_Framework_TestCase
         $results[] = new DateTime('2014-03-24 00:00:00');
         $results[] = new DateTime('2014-03-25 00:00:00');
         $results[] = new DateTime('2014-04-07 00:00:00');
+        $results[] = new DateTime('2014-04-08 00:00:00');
 
         $r = new When();
         $r->startDate(new DateTime("2014-02-10"))


### PR DESCRIPTION
This library gave me a great jump start on supporting recurring events. I've added a few things I'd be happy to see become part of the main line if you agree with them. 

getOccurrencesBetween is the major addition. This returns occurrences between two dates (as when one is displaying just one month of a calendar, for example). The motivation for this was to allow recurrences that lack a COUNT or UNTIL_DATE to be used without arbitrarily imposing a limit on the number of occurrences. getNextOccurrence and getPrevOccurrence are really just conveniences. 

I made some changes to occursOn and occursAt along the way. My own use case doesn't support frequencies below DAILY, so I probably haven't actually excercised occursAt heavily. 

Thanks! 

(Previously mentioned in #49.)