### PR TITLE
Fixes issues #55 & #58

### DIFF
--- a/src/When.php
+++ b/src/When.php
@@ -837,11 +837,11 @@ class When extends \DateTime
 
                 foreach ($this->bysetpos as $setpos)
                 {
-                    if ($setpos > 0)
+                    if ($setpos > 0 && isset($occurrences[$setpos - 1]))
                     {
                         $filtered_occurrences[] = $occurrences[$setpos - 1];
                     }
-                    else
+                    elseif(isset($occurrences[$occurrenceCount + $setpos]))
                     {
                         $filtered_occurrences[] = $occurrences[$occurrenceCount + $setpos];
                     }

--- a/tests/WhenMonthlyRruleTest.php
+++ b/tests/WhenMonthlyRruleTest.php
@@ -520,4 +520,30 @@ class WhenMonthlyRruleTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($result, $occurrences[$key]);
         }
     }
+
+    /**
+     * Every 2nd Monday every month for 4 months (issue #55)
+     * Checking single BYDAY with BYSETPOS while Monthly
+     * DTSTART;TZID=America/New_York:19970908T090000
+     * RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=2;COUNT=4
+     */
+    function testMonthlySeventeen()
+    {
+        $results[] = new DateTime("1997-09-08 09:00:00");
+        $results[] = new DateTime("1997-10-13 09:00:00");
+        $results[] = new DateTime("1997-11-10 09:00:00");
+        $results[] = new DateTime("1997-12-08 09:00:00");
+
+        $r = new When();
+        $r->startDate(new DateTime("19970908T090000"))
+          ->rrule("FREQ=MONTHLY;BYDAY=MO;BYSETPOS=2;COUNT=4")
+          ->generateOccurrences();
+
+        $occurrences = $r->occurrences;
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
 }

--- a/tests/WhenOccurrencesBetweenTest.php
+++ b/tests/WhenOccurrencesBetweenTest.php
@@ -237,4 +237,31 @@ class WhenOccurrencesBetweenTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * First 4 2nd Fridays between July 3 - Nov 3 2016
+     * Checking against BYSETPOS caused undefined offset
+     * DTSTART;TZID=America/New_York:20160610T090000
+     * RRULE:FREQ=MONTHLY;BYDAY=FR;BYSETPOS=2;COUNT=3;
+     */
+    function testGetMonthlyOccurrencesBysetposUndefinedOffset()
+    {
+        $results[] = new DateTime("2016-07-08 09:00:00");
+        $results[] = new DateTime("2016-08-12 09:00:00");
+        $results[] = new DateTime("2016-09-09 09:00:00");
+        $results[] = new DateTime("2016-10-14 09:00:00");
+
+        $r = new When();
+        $r->startDate(new DateTime("20160610T090000"))
+          ->rrule("FREQ=MONTHLY;BYDAY=FR;BYSETPOS=2");
+        $occurrences = $r->getOccurrencesBetween(
+            new DateTime( "20160703T090000" ),
+            new DateTime( "20161103T090000" )
+        );
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
+
 }

--- a/tests/WhenOccurrencesBetweenTest.php
+++ b/tests/WhenOccurrencesBetweenTest.php
@@ -211,4 +211,30 @@ class WhenOccurrencesBetweenTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($occurrences));
     }
 
+    /**
+     * Every 2nd Monday between Sept 1 - Dec 1 1997 (issue #58)
+     * Checking single BYDAY with BYSETPOS while Monthly
+     * DTSTART;TZID=America/New_York:19970908T090000
+     * RRULE:FREQ=MONTHLY;BYDAY=MO;BYSETPOS=2;
+     */
+    function testGetMonthlyOccurrencesBydayBysetpos()
+    {
+        $results[] = new DateTime("1997-09-08 09:00:00");
+        $results[] = new DateTime("1997-10-13 09:00:00");
+        $results[] = new DateTime("1997-11-10 09:00:00");
+
+        $r = new When();
+        $r->startDate(new DateTime("19970908T090000"))
+          ->rrule("FREQ=MONTHLY;BYDAY=MO;BYSETPOS=2;");
+        $occurrences = $r->getOccurrencesBetween(
+            new DateTime( "19970901T090000" ),
+            new DateTime( "19971201T090000" )
+        );
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
+
 }

--- a/tests/WhenOccurrencesBetweenTest.php
+++ b/tests/WhenOccurrencesBetweenTest.php
@@ -264,4 +264,105 @@ class WhenOccurrencesBetweenTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * Check if we capture occurrences beyond rangeLimit (200)
+     * DTSTART;TZID=America/New_York:19970902T090000
+     * RRULE:FREQ=WEEKLY;
+     *
+     * '2001-07-03 09:00:00' = #201
+     * '2001-07-31 09:00:00' = #205
+     */
+    function testOutsideRangeLimit()
+    {
+        $results[] = new DateTime('2001-07-03 09:00:00');
+        $results[] = new DateTime('2001-07-10 09:00:00');
+        $results[] = new DateTime('2001-07-17 09:00:00');
+        $results[] = new DateTime('2001-07-24 09:00:00');
+        $results[] = new DateTime('2001-07-31 09:00:00');
+
+        $r = new When();
+        $r->startDate(new DateTime("19970902T090000"))
+          ->rrule("FREQ=WEEKLY;");
+        $occurrences = $r->getOccurrencesBetween(
+            new DateTime( "20010702T090000" ),
+            new DateTime( "20010801T090000" )
+        );
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
+
+    /**
+     * Check if we capture occurrences within and beyond rangeLimit (200)
+     * DTSTART;TZID=America/New_York:19970902T090000
+     * RRULE:FREQ=WEEKLY;
+     *
+     * '2001-05-22 09:00:00' = #195
+     * '2001-07-31 09:00:00' = #205
+     */
+    function testRangeLimit()
+    {
+        $results[] = new DateTime('2001-05-22 09:00:00');
+        $results[] = new DateTime('2001-05-29 09:00:00');
+        $results[] = new DateTime('2001-06-05 09:00:00');
+        $results[] = new DateTime('2001-06-12 09:00:00');
+        $results[] = new DateTime('2001-06-19 09:00:00');
+        $results[] = new DateTime('2001-06-26 09:00:00');
+        $results[] = new DateTime('2001-07-03 09:00:00');
+        $results[] = new DateTime('2001-07-10 09:00:00');
+        $results[] = new DateTime('2001-07-17 09:00:00');
+        $results[] = new DateTime('2001-07-24 09:00:00');
+        $results[] = new DateTime('2001-07-31 09:00:00');
+
+        $r = new When();
+        $r->startDate(new DateTime("19970902T090000"))
+          ->rrule("FREQ=WEEKLY;");
+        $occurrences = $r->getOccurrencesBetween(
+            new DateTime( "20010521T090000" ),
+            new DateTime( "20010801T090000" )
+        );
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
+
+    /**
+     * Check that we don't alter results
+     * DTSTART;TZID=America/New_York:19970902T090000
+     * RRULE:FREQ=WEEKLY;
+     *
+     * '2001-07-03 09:00:00' = #201
+     * '2001-07-31 09:00:00' = #205
+     */
+    function testCurruptingThis()
+    {
+        $results[] = new DateTime('2001-07-03 09:00:00');
+        $results[] = new DateTime('2001-07-10 09:00:00');
+        $results[] = new DateTime('2001-07-17 09:00:00');
+        $results[] = new DateTime('2001-07-24 09:00:00');
+        $results[] = new DateTime('2001-07-31 09:00:00');
+
+        $r = new When();
+        $r->startDate(new DateTime("19970902T090000"))
+          ->rrule("FREQ=WEEKLY;");
+        $occurrences = $r->getOccurrencesBetween(
+            new DateTime( "20010521T090000" ),
+            new DateTime( "20010612T090000" )
+        );
+
+        $occurrences2 = $r->getOccurrencesBetween(
+            new DateTime( "20010702T090000" ),
+            new DateTime( "20010801T090000" )
+        );
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences2[$key]);
+        }
+    }
+
 }

--- a/tests/WhenWeeklyRruleTest.php
+++ b/tests/WhenWeeklyRruleTest.php
@@ -304,4 +304,30 @@ class WhenWeeklyRruleTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($result, $occurrences[$key]);
         }
     }
+
+    /**
+     * every 1st Mon or Fri every week, for 4 weeks (ticket #55)
+     * I'm sure there is a more useful way to use BYSETPOS weekly...
+     * DTSTART;TZID=America/New_York:19970808T090000
+     * RRULE:FREQ=WEEKLY;BYDAY=MO,FR;COUNT=4;BYSETPOS=1
+     */
+    function testWeeklyNine()
+    {
+        $results[] = new DateTime('1997-08-08 09:00:00');
+        $results[] = new DateTime('1997-08-11 09:00:00');
+        $results[] = new DateTime('1997-08-18 09:00:00');
+        $results[] = new DateTime('1997-08-25 09:00:00');
+
+        $r = new When();
+        $r->startDate(new DateTime("19970808T090000"))
+          ->rrule("FREQ=WEEKLY;BYDAY=MO,FR;COUNT=4;BYSETPOS=1")
+          ->generateOccurrences();
+
+        $occurrences = $r->occurrences;
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
 }

--- a/tests/WhenYearlyRruleTest.php
+++ b/tests/WhenYearlyRruleTest.php
@@ -488,4 +488,51 @@ class WhenYearlyRruleTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * Every 1st Monday in April every year for 2 years (ticket #55)
+     * DTSTART;TZID=America/New_York:19970407T090000
+     * RRULE:FREQ=YEARLY;BYDAY=MO;BYSETPOS=1;BYMONTH=4;COUNT=2
+     */
+    function testYearlyTwelve()
+    {
+        $results[] = new DateTime("1997-04-07 09:00:00");
+        $results[] = new DateTime("1998-04-06 09:00:00");
+
+        $r = new When();
+        $r->startDate(new DateTime("19970407T090000"))
+          ->rrule("FREQ=YEARLY;BYDAY=MO;BYSETPOS=1;BYMONTH=4;COUNT=2")
+          ->generateOccurrences();
+
+        $occurrences = $r->occurrences;
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
+
+    /**
+     * Every 1st Monday, Tuesday, or Wednesday in April every year for 3 years (ticket #55)
+     * DTSTART;TZID=America/New_York:19970407T090000
+     * RRULE:FREQ=YEARLY;BYDAY=MO,TU,WE;BYSETPOS=1;BYMONTH=4;COUNT=3
+     */
+    function testYearlyThirteen()
+    {
+        $results[] = new DateTime("1997-04-07 09:00:00");
+        $results[] = new DateTime("1998-04-01 09:00:00");
+        $results[] = new DateTime("1999-04-05 09:00:00");
+
+        $r = new When();
+        $r->startDate(new DateTime("19970407T090000"))
+          ->rrule("FREQ=YEARLY;BYDAY=MO,TU,WE;BYSETPOS=1;BYMONTH=4;COUNT=3")
+          ->generateOccurrences();
+
+        $occurrences = $r->occurrences;
+
+        foreach ($results as $key => $result)
+        {
+            $this->assertEquals($result, $occurrences[$key]);
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes issue #55 
Refactored existing BYSETPOS limiting logic found in Monthly execution
in generateOccurrences(); expanded to cover Yearly as well as Weekly.
Added appropriate tests as well.

Fixes issue #58 
Updated getOccurrencesBetween() method to utilize generateOccurrences()
method, and thereby inherit all the existing benefits such as BYSETPOS
filtering that exist within generateOccurrences().
Memory footprint has not increased. There is a slight decrease in speed; of the 183 tests there was an increase of time spent from 945ms to 1.04s; in practice this should be negligible.