### PR TITLE
Add special case for jumping from feb 29th to the next year for the last day of the month

### DIFF
--- a/src/When.php
+++ b/src/When.php
@@ -718,7 +718,15 @@ class When extends \DateTime
                 $this->addOccurrence($occurrences);
 
                 $dateLooper = clone $this->startDate;
+                // if we are on feb 29th and we must jump a year, we end up on march 1st, so if the rule is to
+                // always go to the end of february we enforce that
+                $correctForLeap = ($dateLooper->format('m-d') === '02-29'
+                    && in_array('2', $this->bymonths, true)
+                    && in_array('-1', $this->bymonthdays, true));
                 $dateLooper->add(new \DateInterval('P' . ($this->interval * ++$count) . 'Y'));
+                if ($correctForLeap) {
+                    $dateLooper->modify('last day of february');
+                }
             }
             else if ($this->freq === "monthly")
             {

--- a/tests/WhenLeapYearTest.php
+++ b/tests/WhenLeapYearTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Andrea Faulds <ajf@ajf.me>
+ */
+
+class WhenLeapYearTest extends PHPUnit_Framework_TestCase
+{
+    public function testRRuleEndOfMonthOnLeapYear()
+    {
+        $recur = new \When\When;
+        $recur->startDate(new \DateTime('2016-02-29 00:00:00'))->rrule('FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=-1');
+        $recur->rangeLimit = 5;
+        $recur->generateOccurrences();
+
+        $dates = array(
+            '2016-02-29 00:00:00',
+            '2017-02-28 00:00:00',
+            '2018-02-28 00:00:00',
+            '2019-02-28 00:00:00',
+            '2020-02-29 00:00:00'
+        );
+        foreach ($dates as $i => $d) {
+            $dt = new \DateTime($d, new \DateTimeZone('UTC'));
+            $this->assertEquals($dt, $recur->occurrences[$i]);
+        }
+    }
+
+    public function testRRuleEndOfMonthByMonthOnLeapYear()
+    {
+        $recur = new \When\When();
+        $recur->startDate(new \DateTime('2016-02-29 00:00:00'))->rrule('FREQ=MONTHLY;BYMONTHDAY=-1');
+        $recur->rangeLimit = 5;
+        $recur->generateOccurrences();
+
+        $dates = array(
+            '2016-02-29 00:00:00',
+            '2016-03-31 00:00:00',
+            '2016-04-30 00:00:00',
+            '2016-05-31 00:00:00',
+            '2016-06-30 00:00:00'
+        );
+        foreach ($dates as $i => $d) {
+            $dt = new \DateTime($d, new \DateTimeZone('UTC'));
+            $this->assertEquals($dt, $recur->occurrences[$i]);
+        }
+    }
+
+    public function testRRuleEndOfMonthByMonthOnLeapYear2()
+    {
+        $recur = new \When\When;
+        $recur->startDate(new \DateTime('2020-01-31 00:00:00'))->rrule('FREQ=MONTHLY;BYMONTHDAY=-1,3');
+        $recur->rangeLimit = 5;
+        $recur->generateOccurrences();
+
+        $dates = array(
+            '2020-01-31 00:00:00',
+            '2020-02-03 00:00:00',
+            '2020-02-29 00:00:00',
+            '2020-03-03 00:00:00',
+            '2020-03-31 00:00:00'
+        );
+        foreach ($dates as $i => $d) {
+            $dt = new \DateTime($d, new \DateTimeZone('UTC'));
+            $this->assertEquals($dt, $recur->occurrences[$i]);
+        }
+    }
+
+    public function testRRuleEndOfMonthOnRegularYear()
+    {
+        $recur = new \When\When;
+        $recur->startDate(new \DateTime('2016-01-31 00:00:00'))->rrule('FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=-1');
+        $recur->rangeLimit = 3;
+        $recur->generateOccurrences();
+
+        $dates = array(
+            '2016-01-31 00:00:00',
+            '2017-01-31 00:00:00',
+            '2018-01-31 00:00:00'
+        );
+        foreach ($dates as $i => $d) {
+            $dt = new \DateTime($d, new \DateTimeZone('UTC'));
+            $this->assertEquals($dt, $recur->occurrences[$i]);
+        }
+    }
+
+    public function testRRuleEndOfMonthByMonth()
+    {
+        $recur = new \When\When;
+        $recur->startDate(new \DateTime('2016-01-31 00:00:00'))->rrule('FREQ=MONTHLY;BYMONTHDAY=-1');
+        $recur->rangeLimit = 3;
+        $recur->generateOccurrences();
+
+        $dates = array(
+            '2016-01-31 00:00:00',
+            '2016-02-29 00:00:00',
+            '2016-03-31 00:00:00'
+        );
+        foreach ($dates as $i => $d) {
+            $dt = new \DateTime($d, new \DateTimeZone('UTC'));
+            $this->assertEquals($dt, $recur->occurrences[$i]);
+        }
+    }
+}


### PR DESCRIPTION
This is based on Jordi Boggiano (@seldaek)'s 2015-11-11 fix to the outdated version of When in use within the Teamup Calendar codebase. We're looking to switch to the latest version, and this was the only thing that was broken, because this fix never got upstreamed. Thus the pull request. ^^