### PR TITLE
fix implode calls

### DIFF
--- a/src/When.php
+++ b/src/When.php
@@ -62,7 +62,7 @@ class When extends DateTime
             return $this;
         }
 
-        throw new InvalidArgumentException("freq: Accepts " . rtrim(implode(Valid::$frequencies, ", "), ","));
+        throw new InvalidArgumentException("freq: Accepts " . rtrim(implode(", ", Valid::$frequencies), ","));
     }
 
     public function until($endDate)
@@ -244,7 +244,7 @@ class When extends DateTime
             return $this;
         }
 
-        throw new InvalidArgumentException("wkst: Accepts " . rtrim(implode(Valid::$weekDays, ", "), ","));
+        throw new InvalidArgumentException("wkst: Accepts " . rtrim(implode(", ", Valid::$weekDays), ","));
     }
 
     public function rrule($rrule)


### PR DESCRIPTION
With PHP 8

`Failed asserting that exception of type "TypeError" matches expected exception "InvalidArgumentException". Message was: "implode(): Argument #2 ($array) must be of type ?array, string given" at
`

Using this patch

```
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.4RC1
Configuration: /dev/shm/BUILD/When-09182e1707085382b8207c480120e96e98880563/phpunit.xml

...............................................................  63 / 197 ( 31%)
............................................................... 126 / 197 ( 63%)
............................................................... 189 / 197 ( 95%)
........                                                        197 / 197 (100%)

Time: 321 ms, Memory: 4.00MB

OK (197 tests, 1972 assertions)

```